### PR TITLE
Rake for project load

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1> Scribe API </h1>
-Scribe is a framework for crowdsourcing the transcription of text-based documents, particularly documents that are not well suited for Optical Character Recognition. 
+Scribe is a framework for crowdsourcing the transcription of text-based documents, particularly documents that are not well suited for Optical Character Recognition.
 
 Check out the <a href="http://docs.scribeapi1.apiary.io/#reference">documentation</a> and the <a href="https://github.com/zooniverse/ScribeAPI/wiki">wiki</a> for further resources.
 
@@ -10,13 +10,9 @@ This application was generated with the rails_apps_composer gem:
 https://github.com/RailsApps/rails_apps_composer
 provided by the RailsApps Project:
 http://railsapps.github.io/
-________________________
 
 Recipes:
 ["apps4", "controllers", "core", "email", "extras", "frontend", "gems", "git", "init", "models", "prelaunch", "railsapps", "readme", "routes", "saas", "setup", "testing", "views"]
 
 Preferences:
 {:git=>true, :apps4=>"none", :dev_webserver=>"webrick", :prod_webserver=>"same", :database=>"mongodb", :orm=>"mongoid", :templates=>"erb", :unit_test=>"rspec", :integration=>"cucumber", :continuous_testing=>"none", :fixtures=>"none", :frontend=>"none", :email=>"gmail", :authentication=>"devise", :devise_modules=>"default", :authorization=>"none", :form_builder=>"none", :starter_app=>"users_app", :rvmrc=>false, :quiet_assets=>true, :better_errors=>true}
-
-
-

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -2,14 +2,11 @@ class Project
 	include Mongoid::Document
 	include Mongoid::Timestamps
 
-	field  :producer, 		 				type: String
 	field  :title, 		   					type: String
-	field  :home_page_content,		type: String
 	field  :summary, 		 					type: String
-	field  :description, 					type: String
+	field  :home_page_content,		type: String
 	field  :organizations, 				type: Array
-	field  :scientists, 	 				type: Array
-	field  :developers, 	 				type: Array
+	field	 :team,									type: Array
 	field  :pages,         				type: Array
 	field  :background,    				type: String
 

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -1,5 +1,5 @@
 class ProjectSerializer < ActiveModel::MongoidSerializer
-  attributes :id, :title ,:summary ,:description, :home_page_content ,:organizations ,:scientists ,:developers, :workflows, :background, :pages
+  attributes :id, :title, :summary, :home_page_content, :organizations , :team, :pages, :background, :workflows 
   has_many :workflows
 
   def id

--- a/lib/tasks/load_project.rake
+++ b/lib/tasks/load_project.rake
@@ -1,0 +1,19 @@
+require Rails.root.join('project', 'example_project', 'project.rb')
+
+desc 'creates a poject object from the project directory'
+  include ActiveModel::Serialization
+
+  task :project_load, [:project_name] => :environment do |task, args|
+    project_file_path = Rails.root.join('project', args[:project_name], 'project.rb')
+
+    project = Project.create({
+        title: Specific_project[:title],
+        summary: Specific_project[:summary],
+        # home_page_content: Specific_project[:home_page_content],
+        organizations: Specific_project[:organizations] ,
+        team: Specific_project[:team],
+        # pages: Specific_project[:pages],
+      })
+
+    binding.pry
+  end

--- a/lib/tasks/load_subjects.rake
+++ b/lib/tasks/load_subjects.rake
@@ -71,6 +71,7 @@ require 'active_support'
           retire_count: retire_count,
           meta_data: meta_data
           })
+          
       end
 
     end

--- a/project/example_project/project.rb
+++ b/project/example_project/project.rb
@@ -1,4 +1,4 @@
-project = {
+Specific_project = {
   title: "Animals vs Cats",
   summary: "We want to see if (yes obviously) cats are better than animals",
   team: [


### PR DESCRIPTION
Adds the following rake task for creating projects from the project directory. The task still needs to integrate home_page_content and pages.
rake project_load[project_name]                                    # creates a poject object from the project directory