### PR TITLE
Asset pipeline fix

### DIFF
--- a/app/assets/javascripts/components/group-browser.cjsx
+++ b/app/assets/javascripts/components/group-browser.cjsx
@@ -1,7 +1,7 @@
 # @cjsx React.DOM
 
 React = require 'react'
-API   = require '../lib/API'
+API   = require '../lib/api'
 
 GroupBrowser = React.createClass
   displayName: 'GroupBrowser'


### PR DESCRIPTION
'API' to 'api' in group-browser.cjsx