### PR TITLE
Transcribe transition

### DIFF
--- a/app/assets/javascripts/components/app.cjsx
+++ b/app/assets/javascripts/components/app.cjsx
@@ -73,7 +73,7 @@ App = React.createClass
               name='transcribe_specific'
               workflow={(workflow for workflow in workflows when workflow.name is 'transcribe')[0]} />
             <Route
-              path='/transcribe/:subject_set_id'
+              path='/transcribe/:subject_id'
               handler={Transcribe}
               name='transcribe'
               workflow={(workflow for workflow in workflows when workflow.name is 'transcribe')[0]} />

--- a/app/assets/javascripts/components/subject-viewer.cjsx
+++ b/app/assets/javascripts/components/subject-viewer.cjsx
@@ -268,8 +268,11 @@ module.exports = React.createClass
         console.log 'SELECTED MARK: ', @state.selectedMark
 
         selectedMark = @state.selectedMark
+        console.log 'CHILD_SUBJECT_ID: ', response.classification.child_subject_id
         selectedMark.child_subject_id = response.classification.child_subject_id
-        @setState selectedMark: selectedMark, => console.log 'UPDATED MARK WITH CHILD SUBJECT ID: ', @state.selectedMark
+        @setState selectedMark: selectedMark, =>
+          console.log 'UPDATED MARK WITH CHILD SUBJECT ID: ', @state.selectedMark
+          @forceUpdate()
 
         # console.log 'TEST ANNOTATION: ', @props.annotation.value.child_subject_id = response.child_subject.id
         # @setTranscribeSubject(key, response._id.$oid)
@@ -334,6 +337,9 @@ module.exports = React.createClass
           { # DISPLAY PREVIOUS MARKS
 
             for mark, i in @props.subject.child_subjects_info
+
+              console.log 'PREVIOUS MARK: ', mark
+
               toolName = mark.data.toolName
               ToolComponent = markingTools[toolName]
               scale = @getScale()
@@ -398,6 +404,8 @@ module.exports = React.createClass
               if taskDescription.tool is 'pickOneMarkOne' #or taskDescription.tool is 'transcribe'
                 <g key={annotation._key} className="marks-for-annotation" data-disabled={isPriorMark or null}>
                   {for mark, m in annotation.value
+
+                    console.log 'NEW MARK: ', mark
 
                     mark._key ?= Math.random()
                     toolDescription = taskDescription.tools[mark.tool]

--- a/app/assets/javascripts/components/subject-viewer.cjsx
+++ b/app/assets/javascripts/components/subject-viewer.cjsx
@@ -264,8 +264,14 @@ module.exports = React.createClass
       })
       .done (response) =>
         console.log "Success", response #, #response #, response._id.$oid
-        console.log 'RECEIVED SECONDARY SUBJECT ID: ', response.child_subject_id
+        console.log 'RECEIVED SECONDARY SUBJECT ID: ', response
         console.log 'SELECTED MARK: ', @state.selectedMark
+
+        selectedMark = @state.selectedMark
+        selectedMark.child_subject_id = response.classification.child_subject_id
+        @setState selectedMark: selectedMark, => console.log 'UPDATED MARK WITH CHILD SUBJECT ID: ', @state.selectedMark
+
+        # console.log 'TEST ANNOTATION: ', @props.annotation.value.child_subject_id = response.child_subject.id
         # @setTranscribeSubject(key, response._id.$oid)
         # @enableMarkButton(key)
         return

--- a/app/assets/javascripts/components/transcribe/index.cjsx
+++ b/app/assets/javascripts/components/transcribe/index.cjsx
@@ -21,7 +21,6 @@ module.exports = React.createClass # rename to Classifier
   mixins: [FetchSubjectsMixin] # load subjects and set state variables: subjects, currentSubject, classification
 
   getInitialState: ->
-    # TODO: why is workflow an array!?!?
     workflow: @props.workflow
 
   getDefaultProps: ->
@@ -120,6 +119,17 @@ module.exports = React.createClass # rename to Classifier
       console.log "go back"
 
   render: ->
+
+
+    console.log 'COMONENT DID MOUNT'
+    if @props.query.scrollX? and @props.query.scrollY?
+      console.log 'SCROLLING...'
+      window.scrollTo(@props.query.scrollX,@props.query.scrollY)
+
+
+
+
+
     console.log "Transcribe#render: ", @state
     console.log "Transcribe#render: classification: ", @props.classification
     return null unless @state.currentTask?

--- a/app/assets/javascripts/lib/fetch-subjects-mixin.cjsx
+++ b/app/assets/javascripts/lib/fetch-subjects-mixin.cjsx
@@ -63,8 +63,10 @@ module.exports =
   #     @fetchSubjects @props.workflow.id, @props.workflow.subject_fetch_limit
   #
 
-    if @props.workflow.name is "mark"
-      @fetchSubjectSets @props.workflow.id, @props.workflow.subject_fetch_limit
+    if @props.workflow.name is 'transcribe' and @props.params.subject_id
+      @fetchSubject @props.params.subject_id,@props.workflow.id
+    else if @props.workflow.name is "mark"
+        @fetchSubjectSets @props.workflow.id, @props.workflow.subject_fetch_limit
     else
       @fetchSubjects @props.workflow.id, @props.workflow.subject_fetch_limit
 
@@ -77,10 +79,13 @@ module.exports =
       currentSubject: null
 
     request.then (subject)=>
-      console.log("retrived subejct set", subject_set)
+      console.log("retrived subejct set", subject)
       @setState
-        subject: [subject]
+        subjects: [subject]
         currentSubject: subject
+
+      if @fetchSubjectsCallback?
+        @fetchSubjectsCallback()
 
   fetchSubjects: (workflow_id, limit) ->
     console.log 'fetchSubjects()'

--- a/app/assets/javascripts/lib/mark-button-mixin.cjsx
+++ b/app/assets/javascripts/lib/mark-button-mixin.cjsx
@@ -76,7 +76,8 @@ module.exports =
         # @submitTranscription()
         console.log 'Transcription submitted.'
       when 'transcribe-finished'
-        location.replace '/#/transcribe'
+        console.log 'TRANSCRIBING MARK WITH ID: ', @props.mark.child_subject_id
+        location.replace "/#/transcribe/#{@props.mark.child_subject_id}"
         # @setState locked: true
         console.log 'All done. Nothing left to do here.'
       else

--- a/app/assets/javascripts/lib/mark-button-mixin.cjsx
+++ b/app/assets/javascripts/lib/mark-button-mixin.cjsx
@@ -77,7 +77,7 @@ module.exports =
         console.log 'Transcription submitted.'
       when 'transcribe-finished'
         console.log 'TRANSCRIBING MARK WITH ID: ', @props.mark.child_subject_id
-        location.replace "/#/transcribe/#{@props.mark.child_subject_id}"
+        location.replace "/#/transcribe/#{@props.mark.child_subject_id}?scrollX=#{window.scrollX}&scrollY=#{window.scrollY}"
         # @setState locked: true
         console.log 'All done. Nothing left to do here.'
       else


### PR DESCRIPTION
Enables users to click on the "transcribe" button after individual marks have been committed. Changes include: 

* passing child_subject_id from classification response to mark/annotation
* save window scroll values to scrollTo mark position in transcribe route
