### PR TITLE
Fix tool selection

### DIFF
--- a/app/assets/javascripts/components/core-tools/pick-one-mark-one.cjsx
+++ b/app/assets/javascripts/components/core-tools/pick-one-mark-one.cjsx
@@ -92,7 +92,7 @@ module.exports = React.createClass
     subToolIndex: 0
 
   render: ->
-
+    console.log 'PICK-ONE-MARK-ONE::render()'
     console.log 'PROPS: ', @props
 
     tools = for tool, i in @props.task.tool_config.tools

--- a/app/assets/javascripts/components/mark/index.cjsx
+++ b/app/assets/javascripts/components/mark/index.cjsx
@@ -165,6 +165,8 @@ module.exports = React.createClass # rename to Classifier
     @setState
       classifications: classifications
       classificationIndex: classifications.length-1
+        ,=>
+          window.classifications = @state.classifications # make accessible to console
 
   # Push current classification to server:
   commitClassification: ->
@@ -178,7 +180,6 @@ module.exports = React.createClass # rename to Classifier
     classification.commit()
 
     console.log 'COMMITTED CLASSIFICATION: ', classification
-    console.log '(ALL CLASSIFICATIONS): ', @state.classifications
 
   # Get current classification:
   getCurrentClassification: ->

--- a/app/assets/javascripts/components/subject-viewer.cjsx
+++ b/app/assets/javascripts/components/subject-viewer.cjsx
@@ -216,8 +216,8 @@ module.exports = React.createClass
       selectedMark: mark, => console.log 'SELECTED MARK: ', mark
 
   render: ->
-    console.log '*********** STATE: ', @state
-    console.log "PROPS in SB render", @props
+    # console.log '*********** STATE: ', @state
+    # console.log "PROPS in SB render", @props
 
 
     viewBox = [0, 0, @state.imageWidth, @state.imageHeight]
@@ -231,12 +231,12 @@ module.exports = React.createClass
       else
         <ActionButton onClick={@nextSubject} text="Next Page" />
 
-    console.log "ARE WE HERE 1"
+    # console.log "ARE WE HERE 1"
     if false && @state.loading
       markingSurfaceContent = <LoadingIndicator />
-      console.log "First clause of the IF"
+      # console.log "First clause of the IF"
     else
-      console.log "ElSE clause"
+      # console.log "ElSE clause"
       markingSurfaceContent =
         <svg
           className = "subject-viewer-svg"
@@ -258,7 +258,13 @@ module.exports = React.createClass
               width = {@state.imageWidth}
               height = {@state.imageHeight} />
           </MouseHandler>
-          {console.log "After SVG Placement"}
+
+          {
+            # DEBUG CODE
+            null
+            #console.log "After SVG Placement"
+          }
+
           { # DISPLAY PREVIOUS MARKS
             for mark, i in @props.subject.child_subjects_info
 

--- a/app/assets/javascripts/components/subject-viewer.cjsx
+++ b/app/assets/javascripts/components/subject-viewer.cjsx
@@ -273,9 +273,9 @@ module.exports = React.createClass
                # = markingTools[toolName]
                 scale = @getScale()
 
-                console.log 'REFS: ', @refs
+                # console.log 'REFS: ', @refs
                 ToolComponent = markingTools[toolName]
-                console.log 'toolComponent: ', ToolComponent, toolName
+                # console.log 'toolComponent: ', ToolComponent, toolName
 
                 <ToolComponent
                   key={i}
@@ -307,7 +307,7 @@ module.exports = React.createClass
               toolName = @props.subject.region.toolName
               mark = @props.subject.region
               ToolComponent = markingTools[toolName]
-              console.log "ToolComponent", ToolComponent
+              # console.log "ToolComponent", ToolComponent
               isPriorMark = true
               <g>
                 { @highlightMark(mark, toolName) }

--- a/app/assets/javascripts/components/subject-viewer.cjsx
+++ b/app/assets/javascripts/components/subject-viewer.cjsx
@@ -84,9 +84,10 @@ module.exports = React.createClass
 
   # Handle initial mousedown:
   handleInitStart: (e) ->
-    console.log "hIS", @props
+    console.log 'SUBJECT-VIEWER::handleInitStart(): ', @props
+
     return null if ! @props.subToolIndex?
-    subTool = @props.task.tool_config.tools[@props.subToolIndex]
+    subTool = @props.task.tool_config.tools[@props.annotation.subToolIndex]
     return null if ! subTool?
 
     # If there's a current, uncommitted mark, commit it:

--- a/project/whale_tales/workflows/mark.json
+++ b/project/whale_tales/workflows/mark.json
@@ -91,7 +91,7 @@
       "instruction":"Pick a tool and mark each record:",
       "tool_config": {
         "tools": [
-          {"type": "textRowTool",     "label": "Point Tool",    "color": "red",   "generates_subject_type": "debug1" },
+          {"type": "pointTool",     "label": "Point Tool",    "color": "red",   "generates_subject_type": "debug1" },
           {"type": "rectangleTool", "label": "Drawing/Note",  "color": "green", "generates_subject_type": "debug2" },
           {"type": "textRowTool",   "label": "Journal Entry", "color": "blue",  "generates_subject_type": "debug3" }
         ]

--- a/project/whale_tales/workflows/mark.json
+++ b/project/whale_tales/workflows/mark.json
@@ -91,9 +91,9 @@
       "instruction":"Pick a tool and mark each record:",
       "tool_config": {
         "tools": [
-          {"type": "pointTool",     "label": "Point Tool",    "color": "red",   "generates_subject_type": "debug1" },
-          {"type": "rectangleTool", "label": "Drawing/Note",  "color": "green", "generates_subject_type": "debug2" },
-          {"type": "textRowTool",   "label": "Journal Entry", "color": "blue",  "generates_subject_type": "debug3" }
+          {"type": "pointTool",     "label": "Point Tool",    "color": "red",   "generates_subject_type": "transcribe_point" },
+          {"type": "rectangleTool", "label": "Drawing/Note",  "color": "green", "generates_subject_type": "transcribe_rectangle" },
+          {"type": "textRowTool",   "label": "Journal Entry", "color": "blue",  "generates_subject_type": "transcribe_text_row" }
         ]
       },
       "next_task": "records_present"

--- a/project/whale_tales/workflows/transcribe.json
+++ b/project/whale_tales/workflows/transcribe.json
@@ -1,7 +1,6 @@
 {
   "name": "transcribe",
   "label": "Transcribe Workflow",
-  "first_task": "entry_date",
 
   "generates_subjects": true,
   "generates_subjects_for": "verify",
@@ -10,8 +9,26 @@
   "generates_subjects_method": "collect-unique",
 
   "tasks": {
+    "transcribe_point": {
+      "tool": "text_tool",
+      "tool_config": {},
+      "instruction": "Transcribe this point.",
+      "next_task": null
+    },
+    "transcribe_rectangle": {
+      "tool": "text_tool",
+      "tool_config": {},
+      "instruction": "Transcribe this rectangle.",
+      "next_task": null
+    },
+    "transcribe_text_row": {
+      "tool": "text_tool",
+      "tool_config": {},
+      "instruction": "Transcribe this text row.",
+      "next_task": null
+    },
     "entry_date": {
-      "tool": "dateTool",
+      "tool": "text_tool",
       "tool_config": {},
       "instruction": "What is the entry date?",
       "next_task": "page_number"


### PR DESCRIPTION
This addresses what was preventing the right tools to be selected:

 subToolIndex was being used in 2 places, 1) as a state variable in mark/index, and 2) as a field within 'annotation'. As far as I can tell, @state.subToolIndex isn't being updated anywhere, which is why we're stuck on tools[0]. I worked around this by setting subToolIndex in the pick-one-mark-one callback (handleChange()) and modifying the following line to use @props.annotation.subToolIndex