### PR TITLE
Remove subject request scope

### DIFF
--- a/app/assets/javascripts/lib/fetch-subject-sets-mixin.cjsx
+++ b/app/assets/javascripts/lib/fetch-subject-sets-mixin.cjsx
@@ -6,7 +6,7 @@ module.exports =
     if @props.query.subject_set_id
       @fetchSubjectSet @props.query.subject_set_id, @props.query.subject_index, @props.workflow.id
     else
-      @fetchSubjectSets @props.workflow.id, @props.workflow.subject_fetch_limit, @props.workflow.subject_request_scope
+      @fetchSubjectSets @props.workflow.id, @props.workflow.subject_fetch_limit
 
   fetchSubjectSet: (subject_set_id, subject_index, workflow_id)->
     console.log 'fetchSubjectSet()'
@@ -23,7 +23,7 @@ module.exports =
         subject_index: parseInt(subject_index) || 0
         # currentSubjectSet: subject_set
 
-  fetchSubjectSets: (workflow_id, limit, subject_request_scope) ->
+  fetchSubjectSets: (workflow_id, limit) ->
     if @props.overrideFetchSubjectsUrl?
       # console.log "Fetching (fake) subject sets from #{@props.overrideFetchSubjectsUrl}"
       $.getJSON @props.overrideFetchSubjectsUrl, (subject_sets) =>
@@ -33,7 +33,6 @@ module.exports =
 
     else
       request = API.type('subject_sets').get
-        subject_request_scope: subject_request_scope
         workflow_id: workflow_id
         limit: limit
         random: true

--- a/app/controllers/subject_sets_controller.rb
+++ b/app/controllers/subject_sets_controller.rb
@@ -5,7 +5,6 @@ class SubjectSetsController < ApplicationController
     workflow_id  = params["workflow_id"]
     random = params["random"] || false
     limit  = params["limit"].to_i  || 10
-    subject_request_scope = params["subject_request_scope"]
     
     if  workflow_id
       query = {"counts.#{workflow_id}.active_subjects" => {"$gt"=>0}}
@@ -22,19 +21,20 @@ class SubjectSetsController < ApplicationController
     # sets = sets.sort_by { |s| - s.subjects.first.secondary_subject_count }
 
     # Randomizer#random seems to want query criteria passed in under :selector key:
-    respond_with sets, each_serializer: SubjectSetSerializer, workflow_id: workflow_id, limit: limit, random: random, subject_request_scope: subject_request_scope
+    respond_with sets, each_serializer: SubjectSetSerializer, workflow_id: workflow_id, limit: limit, random: random
   end
 
   # DOES NOT APPEAR TO BE IN USE -STI
   def show
     limit = 1 # should only return one (the matched set)
+    subject_id = params[:subject_id]
     # limit = params["limit"].to_i || 10
     puts 'SUBJECT SET ID: ', params[:subject_set_id]
     set = SubjectSet.where(id: params[:subject_set_id])
     workflow_id  = params["workflow_id"]
 
     return render status: 404, json: {status: 404} if set.nil?
-    respond_with set, status: (set.nil? ? :not_found : 201), each_serializer: SubjectSetSerializer, workflow_id: workflow_id, limit: limit
+    respond_with set, status: (set.nil? ? :not_found : 201), each_serializer: SubjectSetSerializer, workflow_id: workflow_id, subject_id: subject_id, limit: limit
   end
 
 end

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -15,7 +15,6 @@ class Workflow
   field    :generates_subjects_max,                          type: Integer
   field    :generates_subjects_method,                       type: String,    default: 'one-per-classification'
   field    :active_subjects,                                 type: Integer,   default: 0
-  field    :subject_request_scope,                           type: String,    default: "active"
 
   has_many     :subjects
   has_many     :classifications

--- a/app/serializers/subject_set_serializer.rb
+++ b/app/serializers/subject_set_serializer.rb
@@ -1,10 +1,14 @@
 class SubjectSetSerializer < ActiveModel::MongoidSerializer
 
-  attributes :id, :name, :thumbnail, :meta_data, :subjects, :state, :counts, :group_id
+  attributes :id, :name, :thumbnail, :meta_data, :subjects, :state, :counts, :group_id, :selected_subject_id
   has_many :subjects
 
   def id
     object._id.to_s
+  end
+
+  def selected_subject_id
+    serialization_options[:subject_id] if serialization_options[:subject_id]
   end
 
   def subjects
@@ -14,19 +18,12 @@ class SubjectSetSerializer < ActiveModel::MongoidSerializer
 
     return nil if object.nil?
 
-    if serialization_options[:subject_request_scope] == "active_root"
-      if random
-        object.subjects.active_root.where(workflow_id: workflow_id).random(limit: limit)
-      else
-        object.subjects.active_root.where(workflow_id: workflow_id).limit(limit)
-      end
-    elsif serialization_options[:subject_request_scope] == "active"
-      if random
-        object.subjects.active.where(workflow_id: workflow_id).random(limit: limit)
-      else
-        object.subjects.active.where(workflow_id: workflow_id).limit(limit)
-      end
+    if random
+      subjects = object.subjects.active_root.where(workflow_id: workflow_id).random(limit: limit)     
+    else
+      subjects = object.subjects.active_root.where(workflow_id: workflow_id).limit(limit)
     end
+
   end
 
 end

--- a/app/serializers/workflow_serializer.rb
+++ b/app/serializers/workflow_serializer.rb
@@ -1,5 +1,5 @@
 class WorkflowSerializer < ActiveModel::MongoidSerializer
-  attributes :id, :name, :label, :tasks, :subject_request_scope, :retire_limit, :subject_fetch_limit, :first_task, :active_subjects, :generates_subjects_for
+  attributes :id, :name, :label, :tasks, :retire_limit, :subject_fetch_limit, :first_task, :active_subjects, :generates_subjects_for
 
   def id
     object._id.to_s

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,7 +26,7 @@ API::Application.routes.draw do
   get '/workflows/:workflow_id/subject_sets',                 to: 'subject_sets#index'
   get '/subjects/:subject_id',                                to: 'subjects#show',         defaults: { format: 'json' }
   get '/subject_sets/:subject_set_id',                        to: 'subject_sets#show',     defaults: { format: 'json' }
-  get '/subject_sets/:subject_set_id/subjects/:subject_id',    to: 'subject_sets#show',     defaults: { format: 'json' }
+  get '/workflows/:workflow_id/subject_sets/:subject_set_id/subjects/:subject_id',    to: 'subject_sets#show',     defaults: { format: 'json' }
   get '/classifications/terms/:workflow_id/:annotation_key',  to: 'classifications#terms'
 
   post   '/subjects/:id/favourite',           to: 'favourites#create',     defaults: { format: 'json' }

--- a/project/anzac/workflows/mark.json
+++ b/project/anzac/workflows/mark.json
@@ -1,7 +1,6 @@
 {
   "name":"mark",
   "label":"Mark Workflow",
-  "subject_request_scope": "active_root",
   "subject_fetch_limit":"10",
   "generates_subjects": true,
   "generates_subjects_after": 1,

--- a/project/anzac/workflows/transcribe.json
+++ b/project/anzac/workflows/transcribe.json
@@ -2,7 +2,6 @@
     "name": "transcribe",
     "label": "Transcribe Workflow",
     "retire_limit": 3,
-    "subject_request_scope": "active",
     "generates_subjects": true,
     "generates_subjects_for": "verify",
     "generates_subjects_after": 3,

--- a/project/emigrant/workflows/mark.json
+++ b/project/emigrant/workflows/mark.json
@@ -2,7 +2,6 @@
   "name":"mark",
   "label":"Mark Workflow",
   "subject_fetch_limit":"10",
-  "subject_request_scope": "active_root",
   "generates_subjects": true,
   "generates_subjects_for": "transcribe",
 

--- a/project/emigrant/workflows/transcribe.json
+++ b/project/emigrant/workflows/transcribe.json
@@ -2,7 +2,6 @@
   "name": "transcribe",
   "label": "Transcribe Workflow",
   "retire_limit": 3,
-  "subject_request_scope": "active",
   "generates_subjects": true,
   "generates_subjects_for": "verify",
   "generates_subjects_after": 3,

--- a/project/whale_tales/workflows/mark.json
+++ b/project/whale_tales/workflows/mark.json
@@ -2,7 +2,6 @@
   "name":"mark",
   "label":"Mark Workflow",
   "subject_fetch_limit":     10,
-  "subject_request_scope": "active_root",
   "generates_subjects": true,
   "generates_subjects_after": 1,
   "generates_subjects_for": "transcribe",

--- a/project/whale_tales/workflows/transcribe.json
+++ b/project/whale_tales/workflows/transcribe.json
@@ -2,7 +2,6 @@
   "name": "transcribe",
   "label": "Transcribe Workflow",
   "retire_limit": 3,
-  "subject_request_scope": "active",
   "generates_subjects": true,
   "generates_subjects_for": "verify",
   "generates_subjects_after": 3,


### PR DESCRIPTION
This PR removes the `subject_request_scope` field from the Workflow model as well as the process of querying SubjectSets. 

In addition, this PR adds the route 
`get /workflows/:workflow_id/subject_sets/:subject_set_id/subjects/:subject_id`
for displaying a specific subject within a SubjectSet. `subject_sets#show` should return a subject_set object that contains the key `selected_subject_id` which points to the requested subject. We can use the value of `selected_subject_id` to set the subject_index of the subject-set-viewer.
