### PR TITLE
Transcribe position bugfix

### DIFF
--- a/app/assets/javascripts/components/subject-viewer.cjsx
+++ b/app/assets/javascripts/components/subject-viewer.cjsx
@@ -35,7 +35,7 @@ module.exports = React.createClass
     onLoad: null
     annotationIsComplete: false
 
-  componentWillReceiveProps: (new_props) ->    
+  componentWillReceiveProps: (new_props) ->
     # console.log "SubjectViewer#componentWillReceiveProps: ", @props, new_props
     # @setUncommittedMark null if ! @state.uncommittedMark?.saving && ! new_props.annotation?.subToolIndex?
     # @setUncommittedMark null if ! new_props.annotation?.subToolIndex?
@@ -43,7 +43,6 @@ module.exports = React.createClass
     @setUncommittedMark null if new_props.task?.tool != 'pickOneMarkOne'
 
   componentDidMount: ->
-    console.log "____>>componen DID mount"
     @setView 0, 0, @props.subject.width, @props.subject.height
     @loadImage @props.subject.location.standard
     window.addEventListener "resize", this.updateDimensions
@@ -171,7 +170,6 @@ module.exports = React.createClass
 
   # PB This is not returning anything but 0, 0 for me; Seems like @refs.sizeRect is empty when evaluated (though nonempty later)
   getScale: ->
-    console.log "getScale() is being called"
     rect = @refs.sizeRect?.getDOMNode().getBoundingClientRect()
     return {horizontal: 1, vertical: 1} if ! rect? || ! rect.width?
     rect ?= width: 0, height: 0
@@ -203,7 +201,7 @@ module.exports = React.createClass
       marks.splice (marks.indexOf mark), 1
       @setState
         marks: marks
-        selectedMark: null, => console.log 'MARKS (after): ', @state.marks
+        selectedMark: null #, => console.log 'MARKS (after): ', @state.marks
 
   # Commit mark
   submitMark: ->
@@ -351,7 +349,8 @@ module.exports = React.createClass
             if @props.children?
               @props.children
               cloneWithProps @props.children,
-                scale: scale # pass scale down to children (for transcribe tools)
+                loading: @state.loading       # pass loading state to current transcribe tool
+                scale: scale                  # pass scale down to children (for transcribe tools)
                #  subject: @props.subject
           }
         </div>

--- a/app/assets/javascripts/components/transcribe/tools/text-tool/index.cjsx
+++ b/app/assets/javascripts/components/transcribe/tools/text-tool/index.cjsx
@@ -14,26 +14,34 @@ TextTool = React.createClass
     if e.target.nodeName is "INPUT" or e.target.nodeName is "TEXTAREA"
       @setState preventDrag: true
 
-    @setState
-      xClick: e.pageX - $('.transcribe-tool').offset().left
-      yClick: e.pageY - $('.transcribe-tool').offset().top
+    # console.log 'e: ', e
+    # @setState
+    #   x: e.pageX - $('.transcribe-tool').offset().left
+    #   y: e.pageY - $('.transcribe-tool').offset().top
 
   handleInitDrag: (e, delta) ->
+    console.log 'E: ', e
     return if @state.preventDrag # not too happy about this one
 
-    dx = e.pageX - @state.xClick - window.scrollX
-    dy = e.pageY - @state.yClick # + window.scrollY
+    dx = e.pageX - @state.x #Click# - window.scrollX
+    dy = e.pageY - @state.y #Click # + window.scrollY
+
+    console.log """
+      state.xClick = #{@state.xClick}
+      e.pageX = #{e.pageX}
+      delta = #{delta.x}
+    """
 
     @setState
-      dx: dx
-      dy: dy #, =>
-      dragged: true
+      x: dx
+      y: dy #, =>
+      dragged: true, => console.log "(x,y)=(#{@state.x},#{@state.y})"
 
   getInitialState: ->
     # compute component location
     {x,y} = @getPosition @props.subject.data
-    dx: x
-    dy: y
+    x: x
+    y: y
     viewerSize: @props.viewerSize
 
   # this can go into a mixin? (common across all transcribe tools)
@@ -64,8 +72,8 @@ TextTool = React.createClass
 
     {x,y} = @getPosition @props.subject.data
     @setState
-      dx: x
-      dy: y, => @forceUpdate() # updates component position on new subject
+      x: x
+      y: y, => @forceUpdate() # updates component position on new subject
 
   componentWillUnmount: ->
     tool_config = @toolConfig()
@@ -77,7 +85,7 @@ TextTool = React.createClass
     @props.tool_config ? @props.task.tool_config
 
   componentDidMount: ->
-    @updatePosition()
+    # @updatePosition()
 
     tool_config = @toolConfig()
     if tool_config.suggest == 'common'
@@ -108,8 +116,8 @@ TextTool = React.createClass
   updatePosition: ->
     if @state.viewerSize? && ! @state.dragged
       @setState
-        dx: @props.subject.data.x * @state.viewerSize.scale.horizontal
-        dy: (@props.subject.data.y + @props.subject.data.height) * @state.viewerSize.scale.vertical
+        x: @props.subject.data.x * @state.viewerSize.scale.horizontal
+        y: (@props.subject.data.y + @props.subject.data.height) * @state.viewerSize.scale.vertical
 
   # this can go into a mixin? (common across all transcribe tools)
   # NOTE: doesn't get called unless @props.standalone is true
@@ -148,8 +156,8 @@ TextTool = React.createClass
 
   render: ->
     style =
-      left: "#{@state.dx*@props.scale.horizontal}px"
-      top: "#{@state.dy*@props.scale.vertical}px"
+      left: "#{@state.x*@props.scale.horizontal}px"
+      top: "#{@state.y*@props.scale.vertical}px"
 
     val = @props.annotation[@fieldKey()]
     val = '' if ! val?
@@ -188,8 +196,8 @@ TextTool = React.createClass
           onDrag={@handleInitDrag}
           onEnd={@handleInitRelease}
           ref="inputWrapper0"
-          x={@state.dx*@props.scale.horizontal}
-          y={@state.dy*@props.scale.vertical}>
+          x={@state.x*@props.scale.horizontal}
+          y={@state.y*@props.scale.vertical}>
 
           <div className="transcribe-tool" style={style}>
             <div className="left">

--- a/app/assets/javascripts/components/transcribe/tools/text-tool/index.cjsx
+++ b/app/assets/javascripts/components/transcribe/tools/text-tool/index.cjsx
@@ -68,7 +68,7 @@ TextTool = React.createClass
 
   componentWillUpdate: ->
     # autofocus text input element
-    @refs[@props.ref || 'input0'].getDOMNode().focus() if @props.focus
+    @refs[@props.ref || 'input0']?.getDOMNode().focus() if @props.focus
 
   componentWillUnmount: ->
     tool_config = @toolConfig()
@@ -151,6 +151,7 @@ TextTool = React.createClass
       e.preventDefault()
 
   render: ->
+    return null if @props.loading # hide transcribe tool while loading image
     style =
       left: "#{@state.x*@props.scale.horizontal}px"
       top: "#{@state.y*@props.scale.vertical}px"

--- a/app/assets/javascripts/components/transcribe/tools/text-tool/index.cjsx
+++ b/app/assets/javascripts/components/transcribe/tools/text-tool/index.cjsx
@@ -26,12 +26,6 @@ TextTool = React.createClass
     dx = e.pageX - @state.x #Click# - window.scrollX
     dy = e.pageY - @state.y #Click # + window.scrollY
 
-    console.log """
-      state.xClick = #{@state.xClick}
-      e.pageX = #{e.pageX}
-      delta = #{delta.x}
-    """
-
     @setState
       x: dx
       y: dy #, =>
@@ -67,13 +61,14 @@ TextTool = React.createClass
     focus: true
 
   componentWillReceiveProps: ->
-    console.log 'PROPS: ', @props
-    @refs[@props.ref || 'input0'].getDOMNode().focus() if @props.focus
-
     {x,y} = @getPosition @props.subject.data
     @setState
       x: x
       y: y, => @forceUpdate() # updates component position on new subject
+
+  componentWillUpdate: ->
+    # autofocus text input element
+    @refs[@props.ref || 'input0'].getDOMNode().focus() if @props.focus
 
   componentWillUnmount: ->
     tool_config = @toolConfig()
@@ -85,7 +80,8 @@ TextTool = React.createClass
     @props.tool_config ? @props.task.tool_config
 
   componentDidMount: ->
-    # @updatePosition()
+    # autofocus text input element (first time)
+    @refs[@props.ref || 'input0'].getDOMNode().focus() if @props.focus
 
     tool_config = @toolConfig()
     if tool_config.suggest == 'common'

--- a/app/assets/javascripts/components/transcribe/tools/text-tool/index.cjsx
+++ b/app/assets/javascripts/components/transcribe/tools/text-tool/index.cjsx
@@ -120,8 +120,6 @@ TextTool = React.createClass
   returnToMarking: ->
     @commitAnnotation()
 
-    console.log 'PROPS:SJKDHKLJSDHSKLJDHKJSLDH ', @props
-
     # transition back to mark
     @replaceWith 'mark', {},
       subject_set_id: @props.subject.subject_set_id

--- a/app/assets/stylesheets/components/transcribe/transcribe-tool.styl
+++ b/app/assets/stylesheets/components/transcribe/transcribe-tool.styl
@@ -22,6 +22,7 @@
         color black
         text-align left
       input
+        outline none
         width 360px
         height 40px
         font-size 1.5em
@@ -31,6 +32,7 @@
         &.input-placeholder
           color red
       textarea
+        outline none
         font-size 1.25em
         resize none
         width 400px

--- a/app/assets/stylesheets/components/transcribe/transcribe-tool.styl
+++ b/app/assets/stylesheets/components/transcribe/transcribe-tool.styl
@@ -9,12 +9,18 @@
 
   .left
     padding-bottom 0.8em
-    input
-      float left
-      margin-left 10px
-      outline none
     .input-field
       display none // auto hide
+      &.active
+        display block
+      label
+        display inherit
+        margin-left 10px
+        margin-right 10px
+        margin-top 10px
+        margin-bottom 10px
+        color black
+        text-align left
       input
         width 360px
         height 40px
@@ -24,17 +30,6 @@
         margin-right 10px
         &.input-placeholder
           color red
-      label
-        display inherit
-        margin-left 10px
-        margin-right 10px
-        margin-top 10px
-        margin-bottom 10px
-        color black
-        text-align left
-
-      &.active
-        display block
       textarea
         font-size 1.25em
         resize none


### PR DESCRIPTION
This PR fixes the following:
* occasional shift in position after a click event in transcribe tool
* autofocus of text input element lost when tool type changes, e.g. from text-tool to text-area-tool
* transcribe tool visible before image fully loads