### PR TITLE
style light box when disabled (resolves #173)

### DIFF
--- a/app/assets/javascripts/components/light-box.cjsx
+++ b/app/assets/javascripts/components/light-box.cjsx
@@ -38,7 +38,8 @@ module.exports = React.createClass
 
     viewBox = [0, 0, 100, 100]
 
-    if @state.folded 
+
+    if @state.folded
       carouselStyle ={
         display: "none"
       }
@@ -46,14 +47,20 @@ module.exports = React.createClass
       text = "Show Lightbox"
     else
       text = "Hide Lightbox"
+
+    classes = []
+    if @props.isDisabled
+      console.log 'LIGHT BOX DISABLED'
+      classes.push 'disabled'
+    else
+      console.log 'LIGHT BOX ENABLED'
+
     <div className="carousel" >
+      <div id="visibility-button" onClick={@handleFoldClick}>{text}</div>
 
-    <div id="visibility-button" onClick={@handleFoldClick}>{text}</div>
-
-
-      <div id="image-list" style={carouselStyle} >
+      <div id="image-list" className={classes} style={carouselStyle} >
         <ul>
-          <li onClick={@shineSelected.bind(this, @findSubjectIndex(@state.first))} className={"active" if @props.subject_index == @findSubjectIndex(@state.first)}>
+          <li onClick={@shineSelected.bind(this, @findSubjectIndex(@state.first))} className={"active" if @props.subject_index == @findSubjectIndex(@state.first) }>
             <span class="page-number">{@state.first.order}</span>
 
             <svg className="light-box-subject" width={125} height={125} viewBox={viewBox} >
@@ -70,7 +77,7 @@ module.exports = React.createClass
               <svg className="light-box-subject" width={125} height={125} viewBox={viewBox} >
                   <SVGImage
                     src = {second.location.standard}
-                    width = {100} 
+                    width = {100}
                     height = {100}
                   />
               </svg>
@@ -90,10 +97,10 @@ module.exports = React.createClass
             </li>
           }
         </ul>
-
-        <ActionButton type={"back"} text="BACK" onClick={@moveBack.bind(this, indexOfFirst)} classes={@backButtonDisable(indexOfFirst)} />
-        <ActionButton type={"next"} text="NEXT" onClick={@moveForward.bind(this, indexOfFirst, third, second)} classes={@forwardButtonDisable(third if third?)} />
       </div>
+
+      <ActionButton type={"back"} text="BACK" onClick={@moveBack.bind(this, indexOfFirst)} classes={@backButtonDisable(indexOfFirst)} />
+      <ActionButton type={"next"} text="NEXT" onClick={@moveForward.bind(this, indexOfFirst, third, second)} classes={@forwardButtonDisable(third if third?)} />
 
     </div>
 

--- a/app/assets/javascripts/components/subject-set-viewer.cjsx
+++ b/app/assets/javascripts/components/subject-set-viewer.cjsx
@@ -42,6 +42,10 @@ module.exports = React.createClass
       return null
 
   render: ->
+    # disable LightBox if work has begun
+    disableLightBox = if @props.task.key isnt @props.workflow.first_task then true else false
+
+
     # console.log 'SUBJECT-SET-VIEWER::render(), subject_index = ', @props.subject_index
     # NOTE: LightBox does not receive correct @props.subject_index. Why? --STI
     <div className="subject-set-viewer">
@@ -52,6 +56,7 @@ module.exports = React.createClass
               subject_set={@props.subject_set}
               subject_index={@props.subject_index}
               key={@props.subject_set.subjects[0].id}
+              isDisabled={disableLightBox}
 
               onSubject={@specificSelection.bind this, @props.subject_index}
               subjectCurrentPage={@props.subjectCurrentPage}

--- a/app/assets/stylesheets/light-box.styl
+++ b/app/assets/stylesheets/light-box.styl
@@ -72,6 +72,15 @@
     &:hover
       background-color: #cdcdcd;
 
+  #image-list
+    cursor pointer
+    opacity 1
+    transition opacity 1s
+    &.disabled
+      transition opacity 1s
+      cursor not-allowed
+      opacity 0.25
+
   ul
     padding-left 0
     list-style none
@@ -87,7 +96,7 @@
       align-items: center
       width: 125px
       border-radius: 12px;
-      cursor: pointer;
+      cursor: inherit;
       &.active
         transition border 0.2, background 0.3s
         background-color: #3A3A3A


### PR DESCRIPTION
Before, the LightBox would be "silently" disabled mid-workflow (any time the current task isn't the first task in the workflow) and it wouldn't be obvious why the pages can't be clicked on. This PR adds CSS to make the LightBox appear disabled when it is.