### PR TITLE
In pick-one-mark-one, only highlight marks in current subject type group

### DIFF
--- a/app/assets/javascripts/components/core-tools/pick-one-mark-one.cjsx
+++ b/app/assets/javascripts/components/core-tools/pick-one-mark-one.cjsx
@@ -61,10 +61,14 @@ module.exports = React.createClass
     # @state.annotation
     # @handleChange 0
   componentWillUnmount:->
-    @setState subToolIndex: 0
+    @setState
+      subToolIndex: 0
+      tool: @props.task?.tool_config.tools[0]
 
   getInitialState: ->
     subToolIndex: 0 # @props.annotation?.subToolIndex ? 0
+    tool: @props.task?.tool_config.tools[0]
+
     # annotation: $.extend({subToolIndex: null}, @props.annotation ? {})
 
   render: ->
@@ -99,6 +103,7 @@ module.exports = React.createClass
           className="drawing-tool-input"
           checked={ i is @getSubToolIndex() }
           ref={"inp-" + i}
+          tool={tool}
           onChange={ @handleChange.bind this, i }
         />
 
@@ -122,12 +127,14 @@ module.exports = React.createClass
   getSubToolIndex: ->
     @state.subToolIndex
 
-  setSubToolIndex: (index) ->
-    @setState subToolIndex: index, () =>
-      @props.onChange? subToolIndex: index
+  updateState: (data) ->
+    @setState data, () =>
+      @props.onChange? data
 
   handleChange: (index, e) ->
     # console.log 'PICK-ONE-MARK-ONE::handleChange(), INDEX = ', index, @refs
     inp = @refs["inp-#{index}"]
     if inp.getDOMNode().checked
-      @setSubToolIndex index
+      @updateState
+        subToolIndex: index
+        tool: inp.props.tool

--- a/app/assets/javascripts/components/mark/index.cjsx
+++ b/app/assets/javascripts/components/mark/index.cjsx
@@ -27,6 +27,7 @@ module.exports = React.createClass # rename to Classifier
     subject_index:                0
     currentSubToolIndex:          0
     helping:                      false
+    currentTool:                  null
 
   componentDidMount: ->
     @getCompletionAssessmentTask()
@@ -44,8 +45,10 @@ module.exports = React.createClass # rename to Classifier
     return null unless @getCurrentSubject()? && @getActiveWorkflow()?
     currentTask = @getCurrentTask()
     TaskComponent = @getCurrentTool()
-    onFirstAnnotation = @state.taskKey == @getActiveWorkflow().first_task
-
+    activeWorkflow = @getActiveWorkflow()
+    firstTask = activeWorkflow.first_task
+    onFirstAnnotation = @state.taskKey == firstTask
+    currentTool = if @state.currentTool then @state.currentTool else @getTasks()[firstTask]?.tool_config.tools?[0]
 
     if currentTask.tool is 'pick_one'
       currentAnswer = currentTask.tool_config.options?[currentAnnotation.value]
@@ -77,6 +80,7 @@ module.exports = React.createClass # rename to Classifier
               prevPage={@prevPage}
               totalSubjectPages={@state.total_subject_pages}
               destroyCurrentClassification={@destroyCurrentClassification}
+              currentTool={currentTool}
             />
         }
       </div>
@@ -137,7 +141,7 @@ module.exports = React.createClass # rename to Classifier
     # @forceUpdate()
     @setState subject_index: index, => @forceUpdate()
     @toggleBadSubject() if @state.badSubject
-         
+
   # User somehow indicated current task is complete; commit current classification
   handleToolComplete: (d) ->
     @handleDataFromTool(d)
@@ -160,6 +164,7 @@ module.exports = React.createClass # rename to Classifier
     # to initialize marks going forward
     if d.subToolIndex? && ! d.x? && ! d.y?
       @setState currentSubToolIndex: d.subToolIndex
+      @setState currentTool: d.tool if d.tool?
 
     else
       # console.log "MARK/INDEX::handleDataFromTool()", d if JSON.stringify(d) != JSON.stringify(@getCurrentClassification()?.annotation)
@@ -176,10 +181,11 @@ module.exports = React.createClass # rename to Classifier
           , =>
             @forceUpdate()
 
+
   destroyCurrentClassification: ->
     classifications = @state.classifications
     classifications.splice(@state.classificationIndex,1)
-    @setState 
+    @setState
       classifications: classifications
       classificationIndex: classifications.length-1
 

--- a/app/assets/javascripts/components/mark/index.cjsx
+++ b/app/assets/javascripts/components/mark/index.cjsx
@@ -27,7 +27,7 @@ module.exports = React.createClass # rename to Classifier
     subject_index:                0
     currentSubToolIndex:          0
     helping:                      false
-    currentTool:                  null
+    currentSubtool:                  null
 
   componentDidMount: ->
     @getCompletionAssessmentTask()
@@ -48,7 +48,7 @@ module.exports = React.createClass # rename to Classifier
     activeWorkflow = @getActiveWorkflow()
     firstTask = activeWorkflow.first_task
     onFirstAnnotation = @state.taskKey == firstTask
-    currentTool = if @state.currentTool then @state.currentTool else @getTasks()[firstTask]?.tool_config.tools?[0]
+    currentSubtool = if @state.currentSubtool then @state.currentSubtool else @getTasks()[firstTask]?.tool_config.tools?[0]
 
     if currentTask.tool is 'pick_one'
       currentAnswer = currentTask.tool_config.options?[currentAnnotation.value]
@@ -80,7 +80,7 @@ module.exports = React.createClass # rename to Classifier
               prevPage={@prevPage}
               totalSubjectPages={@state.total_subject_pages}
               destroyCurrentClassification={@destroyCurrentClassification}
-              currentTool={currentTool}
+              currentSubtool={currentSubtool}
             />
         }
       </div>
@@ -164,7 +164,7 @@ module.exports = React.createClass # rename to Classifier
     # to initialize marks going forward
     if d.subToolIndex? && ! d.x? && ! d.y?
       @setState currentSubToolIndex: d.subToolIndex
-      @setState currentTool: d.tool if d.tool?
+      @setState currentSubtool: d.tool if d.tool?
 
     else
       # console.log "MARK/INDEX::handleDataFromTool()", d if JSON.stringify(d) != JSON.stringify(@getCurrentClassification()?.annotation)

--- a/app/assets/javascripts/components/subject-set-viewer.cjsx
+++ b/app/assets/javascripts/components/subject-set-viewer.cjsx
@@ -79,6 +79,7 @@ module.exports = React.createClass
           onChange={@props.onChange}
           subToolIndex={@props.subToolIndex}
           destroyCurrentClassification={@props.destroyCurrentClassification}
+          currentTool={@props.currentTool}
         />
       }
     </div>

--- a/app/assets/javascripts/components/subject-set-viewer.cjsx
+++ b/app/assets/javascripts/components/subject-set-viewer.cjsx
@@ -79,7 +79,7 @@ module.exports = React.createClass
           onChange={@props.onChange}
           subToolIndex={@props.subToolIndex}
           destroyCurrentClassification={@props.destroyCurrentClassification}
-          currentTool={@props.currentTool}
+          currentSubtool={@props.currentSubtool}
         />
       }
     </div>

--- a/app/assets/javascripts/components/subject-viewer.cjsx
+++ b/app/assets/javascripts/components/subject-viewer.cjsx
@@ -233,12 +233,12 @@ module.exports = React.createClass
   getCurrentMarks: ->
     # Previous marks are really just the region hashes of all child subjects
     marks = []
-    currentTool = @props.currentTool
+    currentSubtool = @props.currentSubtool
     for child_subject, i in @props.subject.child_subjects
       child_subject.region.subject_id = child_subject.id # copy id field into region (not ideal)
       marks[i] = child_subject.region
       marks[i].isTranscribable = !child_subject.user_has_classified && child_subject.status != "retired"
-      marks[i].groupActive = currentTool?.generates_subject_type == child_subject.type
+      marks[i].groupActive = currentSubtool?.generates_subject_type == child_subject.type
 
     # marks = (s for s in (@props.subject.child_subjects ? [] ) when s?.region?).map (m) ->
     #   # {userCreated: false}.merge

--- a/app/assets/javascripts/components/subject-viewer.cjsx
+++ b/app/assets/javascripts/components/subject-viewer.cjsx
@@ -233,10 +233,12 @@ module.exports = React.createClass
   getCurrentMarks: ->
     # Previous marks are really just the region hashes of all child subjects
     marks = []
+    currentTool = @props.currentTool
     for child_subject, i in @props.subject.child_subjects
       child_subject.region.subject_id = child_subject.id # copy id field into region (not ideal)
       marks[i] = child_subject.region
       marks[i].isTranscribable = !child_subject.user_has_classified && child_subject.status != "retired"
+      marks[i].groupActive = currentTool?.generates_subject_type == child_subject.type
 
     # marks = (s for s in (@props.subject.child_subjects ? [] ) when s?.region?).map (m) ->
     #   # {userCreated: false}.merge
@@ -273,7 +275,7 @@ module.exports = React.createClass
       mark._key ?= Math.random()
       continue if ! mark.x? || ! mark.y? # if mark hasn't acquired coords yet, don't draw it yet
       isPriorMark = ! mark.userCreated
-      <g key={mark._key} className="marks-for-annotation" data-disabled={isPriorMark or null}>
+      <g key={mark._key} className="marks-for-annotation#{if mark.groupActive then ' group-active' else ''}" data-disabled={isPriorMark or null}>
         {
           mark._key ?= Math.random()
           ToolComponent = markingTools[mark.toolName]

--- a/project/emigrant/styles.css
+++ b/project/emigrant/styles.css
@@ -184,3 +184,6 @@
 .tool-shape.draggable.committed {
   opacity: 0.35;
 }
+.group-active .tool-shape.draggable.committed {
+  opacity: 1;
+}


### PR DESCRIPTION
_This has only been implemented for Emigrants, but can easily adopted by default globally if that's what we want._

All marks are partially transparent unless it is in the currently selected subject type group. (See #215)