### PR TITLE
Issue 241 pick one config

### DIFF
--- a/app/assets/javascripts/components/core-tools/pick-one-mark-one.cjsx
+++ b/app/assets/javascripts/components/core-tools/pick-one-mark-one.cjsx
@@ -62,6 +62,8 @@ module.exports = React.createClass
     # @handleChange 0
   componentWillUnmount:->
     @setState subToolIndex: 0
+    # Ensure mark/index subToolIndex is set to 0 in case next task uses a pick-one-*
+    @props.onChange? subToolIndex: 0
 
   getInitialState: ->
     subToolIndex: 0 # @props.annotation?.subToolIndex ? 0
@@ -76,7 +78,7 @@ module.exports = React.createClass
       counts[subject.type] ?= 0
       counts[subject.type] += 1
 
-    tools = for tool, i in @props.task.tool_config.tools
+    tools = for tool, i in @props.task.tool_config.options
       tool._key ?= Math.random()
 
       # How many prev marks? (i.e. child_subjects with same generates_subject_type)

--- a/app/assets/javascripts/components/core-tools/pick-one.cjsx
+++ b/app/assets/javascripts/components/core-tools/pick-one.cjsx
@@ -67,14 +67,14 @@ module.exports = React.createClass
     onChange: React.PropTypes.func.isRequired
 
   render: ->
-    answers = for k, answer of @props.task.tool_config.options
+    answers = for answer in @props.task.tool_config.options
 
       answer._key ?= Math.random()
-      checked = k is @props.annotation.value
+      checked = answer.value is @props.annotation.value
       classes = ['minor-button']
       classes.push 'active' if checked
 
-      <LabeledRadioButton key={answer._key} classes={classes.join ' '} value={k} checked={checked} onChange={@handleChange.bind this, k} label={answer.label} />
+      <LabeledRadioButton key={answer._key} classes={classes.join ' '} value={answer.value} checked={checked} onChange={@handleChange.bind this, answer.value} label={answer.label} />
 
     <GenericTask ref="inputs" {...@props} question={@props.task.instruction} answers={answers} />
 

--- a/app/assets/javascripts/components/draggable-modal.cjsx
+++ b/app/assets/javascripts/components/draggable-modal.cjsx
@@ -25,6 +25,7 @@ module.exports = React.createClass
     y = @props.y ? (( $(window).height() - 300) / 2 ) + $(window).scrollTop()
     y = Math.max y, 100
     x = Math.max x, 100
+    x = $(window).width() - width if x > $(window).width() - width
 
     <Draggable x={x} y={y}>
 

--- a/app/assets/javascripts/components/mark/index.cjsx
+++ b/app/assets/javascripts/components/mark/index.cjsx
@@ -48,7 +48,7 @@ module.exports = React.createClass # rename to Classifier
 
 
     if currentTask.tool is 'pick_one'
-      currentAnswer = currentTask.tool_config.options?[currentAnnotation.value]
+      currentAnswer = (a for a in currentTask.tool_config.options when a.value == currentAnnotation.value)[0]
       waitingForAnswer = not currentAnswer
 
     <div className="classifier">

--- a/app/assets/javascripts/components/mark/tools/point-tool/index.cjsx
+++ b/app/assets/javascripts/components/mark/tools/point-tool/index.cjsx
@@ -40,7 +40,7 @@ module.exports = React.createClass
     @props.onChange e
 
   handleMouseDown: ->
-    @props.onSelect @props.mark unless @props.disabled
+    @props.onSelect @props.mark # unless @props.disabled
 
   render: ->
     classes = []
@@ -74,7 +74,6 @@ module.exports = React.createClass
     >
       <g
         className='point-tool'
-        onMouseDown={@handleMouseDown}
       >
 
         <Draggable onDrag={@handleDrag}>

--- a/app/assets/javascripts/components/subject-viewer.cjsx
+++ b/app/assets/javascripts/components/subject-viewer.cjsx
@@ -91,7 +91,7 @@ module.exports = React.createClass
 
     subToolIndex = @props.subToolIndex
     return null if ! subToolIndex?
-    subTool = @props.task.tool_config?.tools?[subToolIndex]
+    subTool = @props.task.tool_config?.options?[subToolIndex]
     return null if ! subTool?
 
     # If there's a current, uncommitted mark, commit it:
@@ -289,23 +289,24 @@ module.exports = React.createClass
               toolName = @props.subject.region.toolName
 
               mark = @props.subject.region
-              console.log "MARK", mark
-              ToolComponent = markingTools[toolName]
-              isPriorMark = true
-              <g>
-                { @highlightMark(mark, toolName) }
-                <ToolComponent
-                  key={@props.subject.id}
-                  mark={mark}
-                  xScale={scale.horizontal}
-                  yScale={scale.vertical}
-                  disabled={isPriorMark}
-                  selected={mark is @state.selectedMark}
-                  getEventOffset={@getEventOffset}
-                  ref={@refs.sizeRect}
-                  onSelect={@selectMark.bind this, @props.subject, mark}
-                />
-              </g>
+
+              if mark.x? && mark.y?
+                ToolComponent = markingTools[toolName]
+                isPriorMark = true
+                <g>
+                  { @highlightMark(mark, toolName) }
+                  <ToolComponent
+                    key={@props.subject.id}
+                    mark={mark}
+                    xScale={scale.horizontal}
+                    yScale={scale.vertical}
+                    disabled={isPriorMark}
+                    selected={mark is @state.selectedMark}
+                    getEventOffset={@getEventOffset}
+                    ref={@refs.sizeRect}
+                    onSelect={@selectMark.bind this, @props.subject, mark}
+                  />
+                </g>
           }
 
           {

--- a/app/assets/javascripts/components/subject-viewer.cjsx
+++ b/app/assets/javascripts/components/subject-viewer.cjsx
@@ -33,10 +33,6 @@ module.exports = React.createClass
     annotationIsComplete: false
 
   componentWillReceiveProps: (new_props) ->
-    # console.log "SubjectViewer#componentWillReceiveProps: ", @props, new_props
-    # @setUncommittedMark null if ! @state.uncommittedMark?.saving && ! new_props.annotation?.subToolIndex?
-    # @setUncommittedMark null if ! new_props.annotation?.subToolIndex?
-    # console.log "setting null because",new_props.task?.tool != 'pickOneMarkOne'
     @setUncommittedMark null if new_props.task?.tool != 'pickOneMarkOne'
     if Object.keys(@props.annotation).length == 0 #prevents back-to-back mark tasks, displaying a duplicate mark from previous tasks.
       @setUncommittedMark null

--- a/app/assets/javascripts/components/transcribe/index.cjsx
+++ b/app/assets/javascripts/components/transcribe/index.cjsx
@@ -104,8 +104,6 @@ module.exports = React.createClass # rename to Classifier
             </DraggableModal>
 
           else if @getCurrentSubject()? and @getCurrentTask()?
-            console.log "@getCurrentTask().key", @getCurrentTask().key
-            console.log "rendering text tool: ", "#{@state.taskKey}.#{@getCurrentSubject().id}", currentAnnotation
             <SubjectViewer
               onLoad={@handleViewerLoad}
               subject={@getCurrentSubject()}

--- a/app/assets/javascripts/components/transcribe/index.cjsx
+++ b/app/assets/javascripts/components/transcribe/index.cjsx
@@ -41,7 +41,7 @@ module.exports = React.createClass # rename to Classifier
   fetchSubjectsCallback: ->
     @setState taskKey: @getCurrentSubject().type if @getCurrentSubject()?
 
-  handleTaskComponentChange: (val) ->
+  __DEP__handleTaskComponentChange: (val) ->
     # console.log "handleTaskComponentChange val", val
     taskOption = @getCurrentTask().tool_config.options[val]
     if taskOption.next_task?
@@ -130,7 +130,7 @@ module.exports = React.createClass # rename to Classifier
                 transcribeTools={transcribeTools}
                 onShowHelp={@toggleHelp if @getCurrentTask().help?}
                 badSubject={@state.badSubject}
-                onBadSubject={@toggleBadSubject}                
+                onBadSubject={@toggleBadSubject}
                 illegibleSubject={@state.illegibleSubject}
                 onIllegibleSubject={@toggleIllegibleSubject}
               />

--- a/app/assets/javascripts/components/transcribe/tools/composite-tool/index.cjsx
+++ b/app/assets/javascripts/components/transcribe/tools/composite-tool/index.cjsx
@@ -15,7 +15,7 @@ CompositeTool = React.createClass
   getInitialState: ->
     annotation: @props.annotation ? {}
     viewerSize: @props.viewerSize
-    active_field_key: (key for key, value of @props.task.tool_config.tools)[0]
+    active_field_key: (key for key, value of @props.task.tool_config.options)[0]
 
   getDefaultProps: ->
     annotation: {}
@@ -54,7 +54,7 @@ CompositeTool = React.createClass
   # Otherwise commit annotation (which is default behavior when there's only one input
   handleCompletedField: ->
     console.log 'handleCompletedField()'
-    field_keys = (annotation_key for annotation_key, tool_config of @props.task.tool_config.tools)
+    field_keys = (c.value for c of @props.task.tool_config.options)
     next_field_key = field_keys[ field_keys.indexOf(@state.active_field_key) + 1 ]
 
     if next_field_key?
@@ -118,7 +118,7 @@ CompositeTool = React.createClass
 
       <label>{@props.task.instruction}</label>
       {
-        for annotation_key, tool_config of @props.task.tool_config.tools
+        for annotation_key, tool_config of @props.task.tool_config.options
           ToolComponent = @props.transcribeTools[tool_config.tool]
           focus = annotation_key is @state.active_field_key
 
@@ -126,7 +126,7 @@ CompositeTool = React.createClass
 
           <ToolComponent
             task={@props.task}
-            tool_config={@props.task.tool_config.tools[annotation_key].tool_config}
+            tool_config={@props.task.tool_config.options[annotation_key].tool_config}
             subject={@props.subject}
             workflow={@props.workflow}
             standalone={false}
@@ -134,7 +134,7 @@ CompositeTool = React.createClass
             onChange={@handleChange}
             onComplete={@handleCompletedField}
             onInputFocus={@handleFieldFocus}
-            label={@props.task.tool_config.tools[annotation_key].label ? ''}
+            label={@props.task.tool_config.options[annotation_key].label ? ''}
             focus={focus}
             scale={@props.scale}
             annotation_key={annotation_key}

--- a/app/assets/javascripts/components/transcribe/tools/text-tool/index.cjsx
+++ b/app/assets/javascripts/components/transcribe/tools/text-tool/index.cjsx
@@ -18,6 +18,8 @@ TextTool = React.createClass
 
   # this can go into a mixin? (common across all transcribe tools)
   getPosition: (data) ->
+    return x: null, y: null if ! data.x?
+
     yPad = 20
     switch data.toolName
       when 'rectangleTool'
@@ -28,7 +30,9 @@ TextTool = React.createClass
         y = data.yLower + yPad
       else # default for pointTool
         x = data.x
-        y = data.y + yPad
+        y = data.y + yPad if data.y?
+    x = @props.subject.width / 2 if ! x?
+    y = @props.subject.height / 2 if ! y?
     return {x,y}
 
   getDefaultProps: ->

--- a/app/assets/javascripts/components/verify/tools/verify-tool/index.cjsx
+++ b/app/assets/javascripts/components/verify/tools/verify-tool/index.cjsx
@@ -69,7 +69,7 @@ VerifyTool = React.createClass
       label = @props.label ? ''
 
     {x,y} = @getPosition @props.subject.region
-    console.log "verify tool rendering with scale: ", @props.scale, x, x*@props.scale.horizontal, y, y*@props.scale.vertical
+    # console.log "verify tool rendering with scale: ", @props.scale, x, x*@props.scale.horizontal, y, y*@props.scale.vertical
     <DraggableModal
       
       header  = {label}

--- a/app/assets/javascripts/lib/draggable.cjsx
+++ b/app/assets/javascripts/lib/draggable.cjsx
@@ -14,11 +14,11 @@ module.exports = React.createClass
     y: @props.y #? 0
     dragged: false
 
-  componentWillReceiveProps: ->
+  componentWillReceiveProps: (new_props) ->
     if ! @state.dragged
       @setState
-        x: @props.x
-        y: @props.y
+        x: new_props.x
+        y: new_props.y
 
   propTypes:
     # children: React.PropTypes.component.isRequired
@@ -55,11 +55,10 @@ module.exports = React.createClass
   handleStart: (e) ->
 
     return if e.button != 0
-    console.log "Draggable: handleStart", @props.disableDragIn.indexOf(e.target.nodeName), e.target.nodeName
+    # console.log "Draggable: handleStart", @props.disableDragIn.indexOf(e.target.nodeName), e.target.nodeName
 
     return if @props.disableDragIn.indexOf(e.target.nodeName) >= 0
     return if $(e.target).parents(@props.disableDragIn.join(',')).length > 0
-    console.log "handleStart"
 
     $el = $(this.getDOMNode())
     pos = $el.position()

--- a/app/assets/javascripts/lib/workflow-methods-mixin.cjsx
+++ b/app/assets/javascripts/lib/workflow-methods-mixin.cjsx
@@ -157,7 +157,6 @@ module.exports =
       nextKey = opt.next_task
     else
       nextKey = @getTasks()[@state.taskKey].next_task
-    console.log "next task: ", nextKey
 
     @getTasks()[nextKey]
 

--- a/app/assets/javascripts/lib/workflow-methods-mixin.cjsx
+++ b/app/assets/javascripts/lib/workflow-methods-mixin.cjsx
@@ -152,10 +152,12 @@ module.exports =
   # Get next logical task
   getNextTask: ->
     task = @getTasks()[@state.taskKey]
-    if task.tool_config?.options?[@getCurrentClassification().annotation?.value]?.next_task?
-      nextKey = task.tool_config.options[@getCurrentClassification().annotation.value].next_task
+    # PB: Moving from hash of options to an array of options
+    if (options = (c for c in task.tool_config?.options when c.value == @getCurrentClassification().annotation?.value)) && options.length > 0 && (opt = options[0])? && opt.next_task?
+      nextKey = opt.next_task
     else
       nextKey = @getTasks()[@state.taskKey].next_task
+    console.log "next task: ", nextKey
 
     @getTasks()[nextKey]
 

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -33,7 +33,7 @@ class Workflow
 
   def create_secondary_subjects(classification)
     task = task_by_key classification.task_key
-    return if task.nil? || ! task.generates_subjects?
+    return if task.nil? || ! task.generates_subjects?(classification)
 
     # If we're here, this task generates subjects; Pass responsibility off to 
     # the configured subject generation method:

--- a/app/models/workflow_task.rb
+++ b/app/models/workflow_task.rb
@@ -38,6 +38,9 @@ class WorkflowTask
   def sub_tool_config(classification=nil)
     if ! classification.nil? && ! (subToolIndex = classification.annotation["subToolIndex"]).nil?
       find_tool_box(subToolIndex.to_i)
+
+    elsif ! classification.nil? && ! (option_value = classification.annotation["value"]).nil? && ! (opt = tool_config["options"].select { |c| c['value'].to_s == option_value }).empty?
+      opt.first
     end
   end
 
@@ -45,21 +48,33 @@ class WorkflowTask
   # If given field name matches a sub-tool, returns that tools config
   def tool_config_for_field(field_name)
     # If field name matches an entry in tool_config.tools, return the nested tool-config
-    puts "::::#{field_name}", tool_config['tools'].inspect
-    if ! tool_config.nil? && ! tool_config['tools'].nil? && tool_config['tools'].is_a?(Hash) && ! tool_config['tools'][field_name].nil?
-      tool_config['tools'][field_name]["tool_config"]
+    # if ! tool_config.nil? && ! tool_config['options'].nil? && tool_config['options'].is_a?(Hash) && ! tool_config['options'][field_name].nil?
+    if ! tool_config.nil? && ! tool_config['options'].nil? && tool_config['options'].is_a?(Hash) && ! (pick_one_config = tool_config['options'].select { |c| c['value'] == field_name }).empty?
+      # tool_config['options'][field_name]["tool_config"]
+      pick_one_config.first["tool_config"]
     else
       tool_config
     end
   end
 
-  def generates_subjects?
-    subtool_generates_subjects = ! (c = tool_config).nil? && ! (c = c['tools']).nil? && ! c.select { |c| ! c['generates_subject_type'].nil? }.empty?
+  def generates_subjects?(classification = nil)
+    # subtool_generates_subjects = ! (c = tool_config).nil? && ! (c = c['options']).nil? && ! c.select { |c| ! c['generates_subject_type'].nil? && (classification.nil? || classification.annotation['value'] == c['value'] }.empty?
+
+    # If this is a pick-one- style task, some of its options may generate subjects
+    # Create hash mapping option_values to generates_subject_type
+    subtool_generates_subjects = nil
+    if ! classification.nil? && ! classification.annotation['value'].nil?
+      subtool_configs = ! (c = tool_config).nil? && ! (c = c['options']).nil? ? c.inject({}) { |h, _c| h[_c['value']] = _c['generates_subject_type']; h } : {}
+      # This task generates subjects for this classification if the classification 
+      # targets a tool option that has a non-nil generates_subject_type:
+      subtool_generates_subjects = subtool_configs[classification.annotation['value'].to_sym]
+    end
+
     ! generates_subject_type.nil? || subtool_generates_subjects || ! has_next_task?
   end
 
   def has_next_task?
-    suboption_has_next_task = ! tool_config.nil? && ! (c = tool_config['options']).nil? && ! c.select { |k,h| puts "inspecting #{h.inspect}"; ! h['next_task'].nil? }.empty?
+    suboption_has_next_task = ! tool_config.nil? && ! (c = tool_config['options']).nil? && ! c.select { |c| ! c['next_task'].nil? }.empty?
     ! next_task.nil? || suboption_has_next_task
   end
 
@@ -67,7 +82,7 @@ class WorkflowTask
   private
 
   def find_tool_box(subToolIndex)
-    tool_config["tools"][subToolIndex] if tool_config["tools"]
+    tool_config["options"][subToolIndex] if tool_config["options"]
   end
 
 end

--- a/lib/tasks/load_project.rake
+++ b/lib/tasks/load_project.rake
@@ -156,7 +156,7 @@ desc 'creates a poject object from the project directory'
       config[:options] = config.delete :tools
     # In Pick-one, structure 'options' as an array rather than a hash:
     elsif task_hash[:tool] == 'pickOne'
-      config[:options] = config[:options].map { |(option_value,config)| config[:value] = option_value; config }
+      config[:options] = config[:options].map { |(option_value,config)| config[:value] = option_value; config } if config[:options].is_a?(Hash)
     end
     config
   end

--- a/lib/tasks/load_project.rake
+++ b/lib/tasks/load_project.rake
@@ -117,6 +117,11 @@ desc 'creates a poject object from the project directory'
             task_config[:key] = task_key.to_s
             # Remove any config params not officially declared as fields of WorkflowTask:
             task_config = task_config.inject({}) { |h, (k,v)| h[k] = v if WorkflowTask.fields.keys.include?(k.to_s); h }
+
+            # Rewrite pick-one-* tool configs to be structured the same per https://github.com/zooniverse/scribeAPI/issues/241
+            # .. Just until project owners update their own configs
+            task_config[:tool_config] = translate_pick_one_tool_config task_config
+
             a << task_config
           end
         end
@@ -142,6 +147,18 @@ desc 'creates a poject object from the project directory'
     end
 
     puts "  WARN: No mark workflow found" if project.workflows.find_by(name: 'mark').nil?
+  end
+
+  def translate_pick_one_tool_config(task_hash)
+    config = task_hash[:tool_config]
+    # In Pick-one-mark-one, rename 'tools' to 'options'
+    if task_hash[:tool] == 'pickOneMarkOne'
+      config[:options] = config.delete :tools
+    # In Pick-one, structure 'options' as an array rather than a hash:
+    elsif task_hash[:tool] == 'pickOne'
+      config[:options] = config[:options].map { |(option_value,config)| config[:value] = option_value; config }
+    end
+    config
   end
 
   def load_images(project_key)

--- a/project/anzac/project.json
+++ b/project/anzac/project.json
@@ -4,7 +4,7 @@
   "summary": "Transcription of New Zealand World War I Personnel Files",
   "background": "assets/anzac/background.png",
   "admin_email": "andrea@zooniverse.org",
-    "team_emails": [ "andrea@zooniverse.org" ],
+    "team_emails": [ "andrea@zooniverse.org", "paulbeaudoin@nypl.org" ],
   "team": [
     {
       "name": "Andrea Simenstad",

--- a/project/anzac/project.json
+++ b/project/anzac/project.json
@@ -4,7 +4,7 @@
   "summary": "Transcription of New Zealand World War I Personnel Files",
   "background": "assets/anzac/background.png",
   "admin_email": "andrea@zooniverse.org",
-    "team_emails": [ "andrea@zooniverse.org", "paulbeaudoin@nypl.org" ],
+    "team_emails": [ "andrea@zooniverse.org" ],
   "team": [
     {
       "name": "Andrea Simenstad",

--- a/project/anzac/workflows/mark.json
+++ b/project/anzac/workflows/mark.json
@@ -49,8 +49,7 @@
           },
           "other_page_type":{
             "label":"Other",
-            "next_task": null,
-            "generates_subject_type": "page_type_other"
+            "next_task": null
           }
         }
       }

--- a/project/anzac/workflows/mark.json
+++ b/project/anzac/workflows/mark.json
@@ -49,7 +49,8 @@
           },
           "other_page_type":{
             "label":"Other",
-            "next_task": null
+            "next_task": null,
+            "generates_subject_type": "page_type_other"
           }
         }
       }

--- a/project/anzac/workflows/transcribe.json
+++ b/project/anzac/workflows/transcribe.json
@@ -8,13 +8,6 @@
     "generates_subjects_max": 10,
     "generates_subjects_method": "collect-unique",
     "tasks": {
-        "page_type_other": {
-            "tool": "textTool",
-            "tool_config": {},
-            "instruction": "This is a page type Other",
-            "generates_subject_type": "transcribed_page_type_other",
-            "next_task": null
-        },
         "att_transcribe_header": {
             "tool": "textTool",
             "tool_config": {},

--- a/project/anzac/workflows/transcribe.json
+++ b/project/anzac/workflows/transcribe.json
@@ -8,6 +8,13 @@
     "generates_subjects_max": 10,
     "generates_subjects_method": "collect-unique",
     "tasks": {
+        "page_type_other": {
+            "tool": "textTool",
+            "tool_config": {},
+            "instruction": "This is a page type Other",
+            "generates_subject_type": "transcribed_page_type_other",
+            "next_task": null
+        },
         "att_transcribe_header": {
             "tool": "textTool",
             "tool_config": {},


### PR DESCRIPTION
Addresses https://github.com/zooniverse/scribeAPI/issues/241 , standardizing representations of pick-one- style tools to use 'options' (instead of 'tools') and specify those options as an array rather than a hash. This simplifies both front- and back-end parsing of tasks when determining next_task and generates_subject_type values.

For now this just dynamically rewrites the structure of the workflow jsons at the point of import - in lieu of actually changing those workflow jsons. After merging this, we should update our proj jsons at our leisure.

This work is the foundation for allowing transcription of non-mark generated subjects. In Mark, if a pick-one task includes an option with a non-null generates_subject_type, a subject will be generated with that type. That generated subject will then appear in Transcribe.

These commits also fix a these semi-related issues:
 1. manually fire onChange when unmounting a pick-one-mark-one component to ensure subj-viewer defaults to first marking tool
 2. fix broken positioning of verify tool
 3. don't completely fall over if a subject in the Transcribe workflow doesn't have a region. In other words, allow transcription of the whole page if the generated subject isn't a mark.