### PR TITLE
Emigrants: Add ability to add transcription in verify step (#199)

### DIFF
--- a/app/assets/javascripts/components/verify/tools/verify-tool/index.cjsx
+++ b/app/assets/javascripts/components/verify/tools/verify-tool/index.cjsx
@@ -1,5 +1,7 @@
 React           = require 'react'
 DraggableModal  = require '../../../draggable-modal'
+GenericButton = require 'components/buttons/generic-button'
+DoneButton    = require 'components/buttons/done-button'
 
 VerifyTool = React.createClass
   displayName: 'VerifyTool'
@@ -15,11 +17,13 @@ VerifyTool = React.createClass
     standalone: true
     annotation_key: 'value'
     focus: true
-   
+    doneButtonLabel: 'Okay'
+    transcribeButtonLabel: 'None of these? Enter your own'
+
   componentWillReceiveProps: ->
     @setState
       annotation: @props.annotation
-   
+
   commitAnnotation: ->
     @props.onComplete @state.annotation
 
@@ -68,14 +72,22 @@ VerifyTool = React.createClass
     if ! @props.standalone
       label = @props.label ? ''
 
+    buttons = null
+    if @props.task?.tool_config.displays_transcribe_button?
+      buttons = []
+      transcribe_url = "/#/transcribe/#{@props.subject?.parent_subject_id}?scrollX=#{window.scrollX}&scrollY=#{window.scrollY}&page=#{@props.subject?._meta?.current_page}"
+      buttons.push <GenericButton label={@props.transcribeButtonLabel} href={transcribe_url} className="ghost small-button help-button" />
+      buttons.push <DoneButton label={@props.doneButtonLabel} onClick={@commitAnnotation} />
+
     {x,y} = @getPosition @props.subject.region
     console.log "verify tool rendering with scale: ", @props.scale, x, x*@props.scale.horizontal, y, y*@props.scale.vertical
     <DraggableModal
-      
+
       header  = {label}
       x={x*@props.scale.horizontal}
       y={y*@props.scale.vertical}
-      onDone  = {@commitAnnotation} >
+      onDone  = {@commitAnnotation}
+      buttons = {buttons}>
 
       <div className="verify-tool-choices">
         { if @props.subject.data.task_prompt?
@@ -97,7 +109,7 @@ VerifyTool = React.createClass
         }
         </ul>
       </div>
-      
+
     </DraggableModal>
 
 module.exports = VerifyTool

--- a/app/assets/javascripts/components/verify/tools/verify-tool/index.cjsx
+++ b/app/assets/javascripts/components/verify/tools/verify-tool/index.cjsx
@@ -73,9 +73,9 @@ VerifyTool = React.createClass
       label = @props.label ? ''
 
     buttons = null
-    if @props.task?.tool_config.displays_transcribe_button?
+    if @props.task?.tool_config.displays_transcribe_button? and @props.subject?
       buttons = []
-      transcribe_url = "/#/transcribe/#{@props.subject?.parent_subject_id}?scrollX=#{window.scrollX}&scrollY=#{window.scrollY}&page=#{@props.subject?._meta?.current_page}"
+      transcribe_url = "/#/transcribe/#{@props.subject.parent_subject_id}?scrollX=#{window.scrollX}&scrollY=#{window.scrollY}&page=#{@props.subject._meta?.current_page}"
       buttons.push <GenericButton label={@props.transcribeButtonLabel} href={transcribe_url} className="ghost small-button help-button" />
       buttons.push <DoneButton label={@props.doneButtonLabel} onClick={@commitAnnotation} />
 

--- a/project/emigrant/workflows/verify.json
+++ b/project/emigrant/workflows/verify.json
@@ -13,14 +13,18 @@
     "em_transcribed_date": {
       "instruction": "Choose the best transcription!",
       "tool": "verifyTool",
-      "tool_config": {},
+      "tool_config": {
+        "displays_transcribe_button": true
+      },
       "generates_subject_type": "consensus_date"
     },
 
     "em_transcribed_record_number": {
       "instruction": "Choose the best transcription!",
       "tool": "verifyTool",
-      "tool_config": {},
+      "tool_config": {
+        "displays_transcribe_button": true
+      },
       "generates_subject_type": "consensus_record_number"
     },
 
@@ -28,28 +32,36 @@
     "em_transcribed_mortgager": {
       "instruction": "Choose the best transcription!",
       "tool": "verifyTool",
-      "tool_config": {},
+      "tool_config": {
+        "displays_transcribe_button": true
+      },
       "generates_subject_type": "consensus_mortgager"
     },
 
     "em_transcribed_address": {
       "instruction": "Choose the best transcription!",
       "tool": "verifyTool",
-      "tool_config": {},
+      "tool_config": {
+        "displays_transcribe_button": true
+      },
       "generates_subject_type": "consensus_address"
     },
 
     "em_transcribed_amount_loaned": {
       "instruction": "Choose the best transcription!",
       "tool": "verifyTool",
-      "tool_config": {},
+      "tool_config": {
+        "displays_transcribe_button": true
+      },
       "generates_subject_type": "consensus_amount_loaned"
     },
 
     "em_transcribed_valuation": {
       "instruction": "Choose the best transcription!",
       "tool": "verifyTool",
-      "tool_config": {},
+      "tool_config": {
+        "displays_transcribe_button": true
+      },
       "generates_subject_type": "consensus_valuation"
     }
   }


### PR DESCRIPTION
Added a small button on the bottom-left side of verify modal which allows user to enter another transcription if none of the options are satisfactory.  I made this configurable in verify.json in project config.  This only applies to Emigrants since no other project has verify step.

Resolves #199 