### PR TITLE
Hide marks

### DIFF
--- a/app/assets/javascripts/components/buttons/bad-subject-button.cjsx
+++ b/app/assets/javascripts/components/buttons/bad-subject-button.cjsx
@@ -7,5 +7,4 @@ module.exports = React.createClass
   render: ->
     label = if @props.active then 'Bad Subject' else 'Bad Subject?'
 
-    <SmallButton label={label} onClick={@props.onClick} className="ghost bad-subject #{'marked-bad' if @props.active}" />
-     
+    <SmallButton label={label} onClick={@props.onClick} className="ghost toggle-button #{'toggled' if @props.active}" />

--- a/app/assets/javascripts/components/buttons/hide-other-marks-button.cjsx
+++ b/app/assets/javascripts/components/buttons/hide-other-marks-button.cjsx
@@ -5,6 +5,6 @@ module.exports = React.createClass
   displayName: 'HideOtherMarksButton'
 
   render: ->
-    label = 'Hide Other Marks' #if @props.active then 'Bad Subject' else 'Hide Other Marks'
+    label = if @props.active then 'Show Other Marks' else 'Hide Other Marks'
 
     <SmallButton label={label} onClick={@props.onClick} className="ghost toggle-button #{'toggled' if @props.active}" />

--- a/app/assets/javascripts/components/buttons/hide-other-marks-button.cjsx
+++ b/app/assets/javascripts/components/buttons/hide-other-marks-button.cjsx
@@ -1,0 +1,10 @@
+React         = require 'react'
+SmallButton   = require './small-button'
+
+module.exports = React.createClass
+  displayName: 'HideOtherMarksButton'
+
+  render: ->
+    label = 'Hide Other Marks' #if @props.active then 'Bad Subject' else 'Hide Other Marks'
+
+    <SmallButton label={label} onClick={@props.onClick} className="ghost bad-subject #{'marked-bad' if @props.active}" />

--- a/app/assets/javascripts/components/buttons/hide-other-marks-button.cjsx
+++ b/app/assets/javascripts/components/buttons/hide-other-marks-button.cjsx
@@ -7,4 +7,4 @@ module.exports = React.createClass
   render: ->
     label = 'Hide Other Marks' #if @props.active then 'Bad Subject' else 'Hide Other Marks'
 
-    <SmallButton label={label} onClick={@props.onClick} className="ghost bad-subject #{'marked-bad' if @props.active}" />
+    <SmallButton label={label} onClick={@props.onClick} className="ghost toggle-button #{'toggled' if @props.active}" />

--- a/app/assets/javascripts/components/buttons/illegible-subject-button.cjsx
+++ b/app/assets/javascripts/components/buttons/illegible-subject-button.cjsx
@@ -7,5 +7,4 @@ module.exports = React.createClass
   render: ->
     label = if @props.active then 'Illegible' else 'Illegible?'
 
-    <SmallButton label={label} onClick={@props.onClick} className="ghost bad-subject #{'marked-bad' if @props.active}" />
-     
+    <SmallButton label={label} onClick={@props.onClick} className="ghost toggle-button #{'toggled' if @props.active}" />

--- a/app/assets/javascripts/components/mark/index.cjsx
+++ b/app/assets/javascripts/components/mark/index.cjsx
@@ -114,6 +114,9 @@ module.exports = React.createClass # rename to Classifier
             { if @state.badSubject
               <p>You&#39;ve marked this subject as BAD. Thanks for flagging the issue! <strong>Press DONE to continue.</strong></p>
             }
+            { if @state.hideOtherMarks
+              <p>Currently displaying only your marks. <strong>Toggle the button again to show all marks to-date.</strong></p>
+            }
           </div>
           <nav className="task-nav">
             { if false

--- a/app/assets/javascripts/components/mark/index.cjsx
+++ b/app/assets/javascripts/components/mark/index.cjsx
@@ -9,6 +9,7 @@ API                     = require '../../lib/api'
 HelpModal               = require 'components/help-modal'
 HelpButton              = require 'components/buttons/help-button'
 BadSubjectButton        = require 'components/buttons/bad-subject-button'
+HideOtherMarksButton    = require 'components/buttons/hide-other-marks-button'
 DraggableModal          = require 'components/draggable-modal'
 
 module.exports = React.createClass # rename to Classifier
@@ -16,7 +17,7 @@ module.exports = React.createClass # rename to Classifier
 
   getDefaultProps: ->
     workflowName: 'mark'
-    hideOtherMarks: true
+    # hideOtherMarks: false
 
   mixins: [FetchSubjectSetsMixin, BaseWorkflowMethods] # load subjects and set state variables: subjects, currentSubject, classification
 
@@ -28,6 +29,7 @@ module.exports = React.createClass # rename to Classifier
     subject_index:                0
     currentSubToolIndex:          0
     helping:                      false
+    hideOtherMarks:               false
 
   componentDidMount: ->
     @getCompletionAssessmentTask()
@@ -40,6 +42,12 @@ module.exports = React.createClass # rename to Classifier
 
   toggleHelp: ->
     @setState helping: not @state.helping
+
+  toggleHideOtherMarks: ->
+    @setState hideOtherMarks: not @state.hideOtherMarks
+    , =>
+      console.log 'SET @state.hidingMarks to: ', @state.hideOtherMarks
+      # @forceUpdate()
 
   render: ->
     return null unless @getCurrentSubject()? && @getActiveWorkflow()?
@@ -78,7 +86,7 @@ module.exports = React.createClass # rename to Classifier
               prevPage={@prevPage}
               totalSubjectPages={@state.total_subject_pages}
               destroyCurrentClassification={@destroyCurrentClassification}
-              hideOtherMarks={@props.hideOtherMarks}
+              hideOtherMarks={@state.hideOtherMarks}
             />
         }
       </div>
@@ -95,6 +103,7 @@ module.exports = React.createClass # rename to Classifier
             { if @getCurrentTask().help?
               <HelpButton onClick={@toggleHelp} />
             }
+            <HideOtherMarksButton onClick={@toggleHideOtherMarks} />
             { if onFirstAnnotation
               <BadSubjectButton active={@state.badSubject} onClick={@toggleBadSubject} />
             }

--- a/app/assets/javascripts/components/mark/index.cjsx
+++ b/app/assets/javascripts/components/mark/index.cjsx
@@ -16,6 +16,7 @@ module.exports = React.createClass # rename to Classifier
 
   getDefaultProps: ->
     workflowName: 'mark'
+    hideOtherMarks: true
 
   mixins: [FetchSubjectSetsMixin, BaseWorkflowMethods] # load subjects and set state variables: subjects, currentSubject, classification
 
@@ -77,6 +78,7 @@ module.exports = React.createClass # rename to Classifier
               prevPage={@prevPage}
               totalSubjectPages={@state.total_subject_pages}
               destroyCurrentClassification={@destroyCurrentClassification}
+              hideOtherMarks={@props.hideOtherMarks}
             />
         }
       </div>
@@ -137,7 +139,7 @@ module.exports = React.createClass # rename to Classifier
     # @forceUpdate()
     @setState subject_index: index, => @forceUpdate()
     @toggleBadSubject() if @state.badSubject
-         
+
   # User somehow indicated current task is complete; commit current classification
   handleToolComplete: (d) ->
     @handleDataFromTool(d)
@@ -179,7 +181,7 @@ module.exports = React.createClass # rename to Classifier
   destroyCurrentClassification: ->
     classifications = @state.classifications
     classifications.splice(@state.classificationIndex,1)
-    @setState 
+    @setState
       classifications: classifications
       classificationIndex: classifications.length-1
 

--- a/app/assets/javascripts/components/mark/index.cjsx
+++ b/app/assets/javascripts/components/mark/index.cjsx
@@ -107,7 +107,7 @@ module.exports = React.createClass # rename to Classifier
             { if @getCurrentTask().help?
               <HelpButton onClick={@toggleHelp} />
             }
-            <HideOtherMarksButton onClick={@toggleHideOtherMarks} />
+            <HideOtherMarksButton active={@state.hideOtherMarks} onClick={@toggleHideOtherMarks} />
             { if onFirstAnnotation
               <BadSubjectButton active={@state.badSubject} onClick={@toggleBadSubject} />
             }

--- a/app/assets/javascripts/components/subject-set-viewer.cjsx
+++ b/app/assets/javascripts/components/subject-set-viewer.cjsx
@@ -79,6 +79,7 @@ module.exports = React.createClass
           onChange={@props.onChange}
           subToolIndex={@props.subToolIndex}
           destroyCurrentClassification={@props.destroyCurrentClassification}
+          hideOtherMarks={@props.hideOtherMarks}
         />
       }
     </div>

--- a/app/assets/javascripts/components/subject-viewer.cjsx
+++ b/app/assets/javascripts/components/subject-viewer.cjsx
@@ -167,6 +167,7 @@ module.exports = React.createClass
       @destroyMark @props.annotation, mark
 
     mark.isUncommitted = true
+    mark.belongsToUser = true
     @setUncommittedMark mark
 
   setUncommittedMark: (mark) ->
@@ -236,6 +237,7 @@ module.exports = React.createClass
       marks[i] = child_subject.region
       marks[i].isTranscribable = !child_subject.user_has_classified && child_subject.status != "retired"
       marks[i].belongsToUser = child_subject.user_has_classified
+      console.log 'child_subject.user_has_classified = ', child_subject.user_has_classified
     # marks = (s for s in (@props.subject.child_subjects ? [] ) when s?.region?).map (m) ->
     #   # {userCreated: false}.merge
     #   m?.region ? {}

--- a/app/assets/javascripts/components/subject-viewer.cjsx
+++ b/app/assets/javascripts/components/subject-viewer.cjsx
@@ -167,7 +167,6 @@ module.exports = React.createClass
       @destroyMark @props.annotation, mark
 
     mark.isUncommitted = true
-    console.log 'MARK: ', mark
     @setUncommittedMark mark
 
   setUncommittedMark: (mark) ->
@@ -230,12 +229,13 @@ module.exports = React.createClass
 
   getCurrentMarks: ->
     # Previous marks are really just the region hashes of all child subjects
+    console.log 'CHILD SUBHECTS: ', @props.subject.child_subjects
     marks = []
     for child_subject, i in @props.subject.child_subjects
       child_subject.region.subject_id = child_subject.id # copy id field into region (not ideal)
       marks[i] = child_subject.region
       marks[i].isTranscribable = !child_subject.user_has_classified && child_subject.status != "retired"
-      marks[i].belongsToUser = child_subject.user_has_classified?
+      marks[i].belongsToUser = child_subject.user_has_classified
     # marks = (s for s in (@props.subject.child_subjects ? [] ) when s?.region?).map (m) ->
     #   # {userCreated: false}.merge
     #   m?.region ? {}
@@ -251,29 +251,24 @@ module.exports = React.createClass
     otherMarks = []
     for mark in marks
       if mark.isTranscribable
-        console.log 'TRANSCRIBABLE: ', mark
         transcribableMarks.push mark
       else
-        console.log 'OTHER: ', mark
         otherMarks.push mark
-
-    console.log '>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> MARKS: ', transcribableMarks, otherMarks
 
     console.log '{transcribableMarks, otherMarks} = ', {transcribableMarks, otherMarks}
     return {transcribableMarks, otherMarks}
 
   renderMarks: (marks) ->
-    console.log 'renderMarks() ', marks
+    console.log 'renderMarks(), marks: ', marks
     return unless marks.length > 0
     scale = @getScale()
     marksToRender = for mark in marks
-      console.log 'mark.isUncommited? = ', mark.isUncommitted?
       mark._key ?= Math.random()
       continue if ! mark.x? || ! mark.y? # if mark hasn't acquired coords yet, don't draw it yet
 
-      # hide others' marks, if button is toggled
-      console.log 'KLJDHSKLJDHSKLJDHS: ', @props.hideOtherMarks
-      continue unless mark.belongsToUser if @props.hideOtherMarks
+      console.log 'MARK BELONGS TO USER? ', mark.belongsToUser
+      if @props.hideOtherMarks
+        continue unless mark.belongsToUser
 
       isPriorMark = ! mark.userCreated
       <g key={mark._key} className="marks-for-annotation" data-disabled={isPriorMark or null}>

--- a/app/assets/javascripts/components/subject-viewer.cjsx
+++ b/app/assets/javascripts/components/subject-viewer.cjsx
@@ -236,7 +236,7 @@ module.exports = React.createClass
       child_subject.region.subject_id = child_subject.id # copy id field into region (not ideal)
       marks[i] = child_subject.region
       marks[i].isTranscribable = !child_subject.user_has_classified && child_subject.status != "retired"
-      marks[i].belongsToUser = child_subject.user_has_classified
+      marks[i].belongsToUser = child_subject.belongs_to_user
       console.log 'child_subject.user_has_classified = ', child_subject.user_has_classified
     # marks = (s for s in (@props.subject.child_subjects ? [] ) when s?.region?).map (m) ->
     #   # {userCreated: false}.merge

--- a/app/assets/javascripts/components/subject-viewer.cjsx
+++ b/app/assets/javascripts/components/subject-viewer.cjsx
@@ -272,6 +272,7 @@ module.exports = React.createClass
       continue if ! mark.x? || ! mark.y? # if mark hasn't acquired coords yet, don't draw it yet
 
       # hide others' marks, if button is toggled
+      console.log 'KLJDHSKLJDHSKLJDHS: ', @props.hideOtherMarks
       continue unless mark.belongsToUser if @props.hideOtherMarks
 
       isPriorMark = ! mark.userCreated

--- a/app/assets/stylesheets/classify.styl
+++ b/app/assets/stylesheets/classify.styl
@@ -242,18 +242,18 @@
       &:last
         margin-right 0
 
-
-.bad-subject
+// currently used for the "Bad Subject" and "Hide Other Marks" buttons
+.toggle-button
   color TERTIARY_NORMAL
   border-color TERTIARY_NORMAL
   margin-right: 3px
 
-  &.marked-bad
+  &.toggled
     border solid 1px darkred
     background-color darkred
     color white
 
-  &.marked-bad:before
+  &.toggled:before
     content '\2713   '
 
 

--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -25,7 +25,7 @@ class Classification
 
   def generate_new_subjects
     if workflow.generates_subjects
-      workflow.create_secondary_subjects(self, user)
+      workflow.create_secondary_subjects(self)
     end
   end
 
@@ -95,7 +95,6 @@ class Classification
     subject.inc classification_count: 1
 
     # Push user_id onto Subject.user_ids using mongo's fast addToSet feature, which ensures uniqueness
-    puts 'ADDING USER ID >>>>>>>>>>>>>>> ', user_id.to_s, ' <<<<<<<<<<<<<<<<<'
     Subject.where({id: subject.id}).find_and_modify({"$addToSet" => {classifying_user_ids: user_id.to_s}})
   end
 

--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -25,7 +25,7 @@ class Classification
 
   def generate_new_subjects
     if workflow.generates_subjects
-      workflow.create_secondary_subjects(self)
+      workflow.create_secondary_subjects(self, user)
     end
   end
 
@@ -95,6 +95,7 @@ class Classification
     subject.inc classification_count: 1
 
     # Push user_id onto Subject.user_ids using mongo's fast addToSet feature, which ensures uniqueness
+    puts 'ADDING USER ID >>>>>>>>>>>>>>> ', user_id.to_s, ' <<<<<<<<<<<<<<<<<'
     Subject.where({id: subject.id}).find_and_modify({"$addToSet" => {classifying_user_ids: user_id.to_s}})
   end
 

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -26,7 +26,7 @@ class Subject
   field :secondary_subject_count,     type: Integer, default: 0
   field :classifying_user_ids,        type: Array
   field :user_has_classified,         type: Boolean, default: false
-  field :belongs_to_user,             type: Boolean, default: false
+  field :created_by_user_id,          type: String
 
   # Need to sort out relationship between these two fields. Are these two fields Is this :shj
   field :retire_count,                type: Integer

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -26,6 +26,7 @@ class Subject
   field :secondary_subject_count,     type: Integer, default: 0
   field :classifying_user_ids,        type: Array
   field :user_has_classified,         type: Boolean, default: false
+  field :belongs_to_user,             type: Boolean, default: false
 
   # Need to sort out relationship between these two fields. Are these two fields Is this :shj
   field :retire_count,                type: Integer

--- a/app/models/subject_generation_method.rb
+++ b/app/models/subject_generation_method.rb
@@ -12,11 +12,11 @@ class SubjectGenerationMethod
     methods[name].new
   end
 
-  def process_classification(classification)
+  def process_classification(classification, user)
     raise "Invalid subject generation method: Attempted to use abstract SubjectGenerationMethod#process_classification"
   end
 
-  def subject_attributes_from_classification(classification)
+  def subject_attributes_from_classification(classification, user)
 
     workflow = classification.subject.workflow
 
@@ -37,8 +37,11 @@ class SubjectGenerationMethod
     end
     region[:label] = task.tool_label classification
 
+    belongs_to_user = classification.user.id == user.id
+
     {
       parent_subject: classification.subject,
+      belongs_to_user: belongs_to_user,
       subject_set: classification.subject.subject_set,
       workflow: workflow_for_new_subject,
       type: subject_type,
@@ -50,7 +53,7 @@ class SubjectGenerationMethod
       height: classification.subject.height
     }
   end
-  
+
   def build_mark_region(classification)
     region = classification.annotation.inject({}) do |h, (k,v)|
       h[k] = v if ['toolName','color'].include? k

--- a/app/models/subject_generation_method.rb
+++ b/app/models/subject_generation_method.rb
@@ -12,11 +12,11 @@ class SubjectGenerationMethod
     methods[name].new
   end
 
-  def process_classification(classification, user)
+  def process_classification(classification)
     raise "Invalid subject generation method: Attempted to use abstract SubjectGenerationMethod#process_classification"
   end
 
-  def subject_attributes_from_classification(classification, user)
+  def subject_attributes_from_classification(classification)
 
     workflow = classification.subject.workflow
 
@@ -39,7 +39,7 @@ class SubjectGenerationMethod
 
     {
       parent_subject: classification.subject,
-      created_by_user_id: user.id,
+      created_by_user_id: classification.user.id,
       subject_set: classification.subject.subject_set,
       workflow: workflow_for_new_subject,
       type: subject_type,

--- a/app/models/subject_generation_method.rb
+++ b/app/models/subject_generation_method.rb
@@ -37,11 +37,9 @@ class SubjectGenerationMethod
     end
     region[:label] = task.tool_label classification
 
-    belongs_to_user = classification.user.id == user.id
-
     {
       parent_subject: classification.subject,
-      belongs_to_user: belongs_to_user,
+      created_by_user_id: user.id,
       subject_set: classification.subject.subject_set,
       workflow: workflow_for_new_subject,
       type: subject_type,

--- a/app/models/subject_generation_methods/collect_unique.rb
+++ b/app/models/subject_generation_methods/collect_unique.rb
@@ -2,9 +2,9 @@ module SubjectGenerationMethods
 
   class CollectUnique < SubjectGenerationMethod
 
-    def process_classification(classification, user)
+    def process_classification(classification)
 
-      atts = subject_attributes_from_classification(classification, user)
+      atts = subject_attributes_from_classification(classification)
 
       atts[:status] = 'inactive'
 

--- a/app/models/subject_generation_methods/collect_unique.rb
+++ b/app/models/subject_generation_methods/collect_unique.rb
@@ -2,9 +2,9 @@ module SubjectGenerationMethods
 
   class CollectUnique < SubjectGenerationMethod
 
-    def process_classification(classification)
+    def process_classification(classification, user)
 
-      atts = subject_attributes_from_classification classification
+      atts = subject_attributes_from_classification(classification, user)
 
       atts[:status] = 'inactive'
 

--- a/app/models/subject_generation_methods/most_popular.rb
+++ b/app/models/subject_generation_methods/most_popular.rb
@@ -2,9 +2,9 @@ module SubjectGenerationMethods
 
   class MostPopular < SubjectGenerationMethod
 
-    def process_classification(classification)
+    def process_classification(classification, user)
 
-      atts = subject_attributes_from_classification classification
+      atts = subject_attributes_from_classification(classification, user)
       atts[:status] = 'inactive'
 
       classification.child_subject = Subject.find_or_initialize_by(workflow: atts[:workflow], parent_subject: atts[:parent_subject], type: atts[:type])

--- a/app/models/subject_generation_methods/most_popular.rb
+++ b/app/models/subject_generation_methods/most_popular.rb
@@ -2,9 +2,9 @@ module SubjectGenerationMethods
 
   class MostPopular < SubjectGenerationMethod
 
-    def process_classification(classification, user)
+    def process_classification(classification)
 
-      atts = subject_attributes_from_classification(classification, user)
+      atts = subject_attributes_from_classification(classification)
       atts[:status] = 'inactive'
 
       classification.child_subject = Subject.find_or_initialize_by(workflow: atts[:workflow], parent_subject: atts[:parent_subject], type: atts[:type])

--- a/app/models/subject_generation_methods/one_per_classification.rb
+++ b/app/models/subject_generation_methods/one_per_classification.rb
@@ -2,9 +2,9 @@ module SubjectGenerationMethods
 
   class OnePerClassification < SubjectGenerationMethod
 
-    def process_classification(classification)
+    def process_classification(classification, user)
 
-      atts = subject_attributes_from_classification classification
+      atts = subject_attributes_from_classification(classification, user)
 
       atts[:data] = classification.annotation.except(:key, :tool, :generates_subject_type)
 

--- a/app/models/subject_generation_methods/one_per_classification.rb
+++ b/app/models/subject_generation_methods/one_per_classification.rb
@@ -2,9 +2,9 @@ module SubjectGenerationMethods
 
   class OnePerClassification < SubjectGenerationMethod
 
-    def process_classification(classification, user)
+    def process_classification(classification)
 
-      atts = subject_attributes_from_classification(classification, user)
+      atts = subject_attributes_from_classification(classification)
 
       atts[:data] = classification.annotation.except(:key, :tool, :generates_subject_type)
 

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -31,14 +31,14 @@ class Workflow
     tasks.where(key: key).first
   end
 
-  def create_secondary_subjects(classification, user)
+  def create_secondary_subjects(classification)
     task = task_by_key classification.task_key
     return if task.nil? || ! task.generates_subjects?
 
     # If we're here, this task generates subjects; Pass responsibility off to
     # the configured subject generation method:
     method = SubjectGenerationMethod.by_name classification.workflow.generates_subjects_method
-    method.process_classification(classification, user)
+    method.process_classification(classification)
   end
 
   def next_workflow

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -31,14 +31,14 @@ class Workflow
     tasks.where(key: key).first
   end
 
-  def create_secondary_subjects(classification)
+  def create_secondary_subjects(classification, user)
     task = task_by_key classification.task_key
     return if task.nil? || ! task.generates_subjects?
 
-    # If we're here, this task generates subjects; Pass responsibility off to 
+    # If we're here, this task generates subjects; Pass responsibility off to
     # the configured subject generation method:
     method = SubjectGenerationMethod.by_name classification.workflow.generates_subjects_method
-    method.process_classification classification
+    method.process_classification(classification, user)
   end
 
   def next_workflow

--- a/app/serializers/subject_serializer.rb
+++ b/app/serializers/subject_serializer.rb
@@ -3,7 +3,7 @@ class SubjectSerializer < ActiveModel::MongoidSerializer
   attributes :id, :type, :parent_subject_id, :workflow_id, :name, :location, :data, :region, :classification_count, :order, :meta_data
   attributes :width, :height, :region, :subject_set_id, :status
   attributes :user_favourite, :user_has_classified, :classifying_user_ids
-  attributes :belongs_to_user
+  attributes :belongs_to_user, :created_by_user_id
 
   delegate :current_or_guest_user, to: :scope
   delegate :current_user, to: :scope
@@ -50,6 +50,13 @@ class SubjectSerializer < ActiveModel::MongoidSerializer
     # user and user.has_classified?(object)
     unless user == nil
       return object.classifying_user_ids.include?(user.id.to_s) # Alternate method? --STI
+    end
+  end
+
+  def belongs_to_user
+    user = scope.nil? ? nil : current_or_guest_user
+    unless user == nil
+      return object.created_by_user_id == user.id.to_s
     end
   end
 

--- a/app/serializers/subject_serializer.rb
+++ b/app/serializers/subject_serializer.rb
@@ -3,6 +3,7 @@ class SubjectSerializer < ActiveModel::MongoidSerializer
   attributes :id, :type, :parent_subject_id, :workflow_id, :name, :location, :data, :region, :classification_count, :order, :meta_data
   attributes :width, :height, :region, :subject_set_id, :status
   attributes :user_favourite, :user_has_classified, :classifying_user_ids
+  attributes :belongs_to_user
 
   delegate :current_or_guest_user, to: :scope
   delegate :current_user, to: :scope


### PR DESCRIPTION
This PR adds the field `created_by_user_id` to the subject model, which saves the user id of the user who generated the subject. It is used to serialize the boolean field `belongs_to_user`, indicating whether the subject was created by the current user. The latter is used as a flag to toggle hiding other users' marks.