### PR TITLE
configurable project-appropriate terms for groups, sets, subjects

### DIFF
--- a/app/assets/javascripts/components/app.cjsx
+++ b/app/assets/javascripts/components/app.cjsx
@@ -2,6 +2,7 @@ React = require("react")
 MainHeader                    = require '../partials/main-header'
 API                           = require '../lib/api'
 AppRouter                     = require './app-router'
+Project                       = require 'models/project.coffee'
 
 {RouteHandler}                = require 'react-router'
 
@@ -16,13 +17,8 @@ App = React.createClass
   componentDidMount: ->
     if ! @state.project?
       API.type('projects').get().then (result)=>
-        project = result[0]
-        @setState project: project #, => console.log ' PROJECT: ', @state.project
-
-  # componentDidUpdate: ->
-  #   # value = $(@refs.inputs.getDOMNode()).find('select')[0].value
-  #   console.log "findDOMnode", $(React.findDOMNode(this))
-  #   console.log "@refs", $(@refs)
+        project = new Project(result[0])
+        @setState project: project
 
   render: ->
     return null if ! @state.project?

--- a/app/assets/javascripts/components/buttons/bad-subject-button.cjsx
+++ b/app/assets/javascripts/components/buttons/bad-subject-button.cjsx
@@ -5,6 +5,6 @@ module.exports = React.createClass
   displayName: 'BadSubjectButton'
 
   render: ->
-    label = if @props.active then 'Bad Subject' else 'Bad Subject?'
+    label = @props.label ? ( if @props.active then 'Bad Subject' else 'Bad Subject?' )
 
     <SmallButton label={label} onClick={@props.onClick} className="ghost toggle-button #{'toggled' if @props.active}" />

--- a/app/assets/javascripts/components/forum-subject-widget.cjsx
+++ b/app/assets/javascripts/components/forum-subject-widget.cjsx
@@ -67,7 +67,7 @@ module.exports = React.createClass
         }
         </ul>
       }
-      <a target="_blank" href={create_url}>Start a discussion about this subject set</a>
+      <a target="_blank" href={create_url}>Start a discussion about this {@props.project.term('subject set')}</a>
     </div>
 
 

--- a/app/assets/javascripts/components/group-browser.cjsx
+++ b/app/assets/javascripts/components/group-browser.cjsx
@@ -49,10 +49,12 @@ GroupBrowser = React.createClass
     </div>
 
   render: ->
+    # Only display GroupBrowser if more than one group defined:
     return null if @state.groups.length <= 1
+
     groups = [@renderGroup(group) for group in @state.groups]
     <div>
-      <h3 className="groups-header"><span>Select a group</span></h3>
+      <h3 className="groups-header"><span>Select a {@props.project.term('group')}</span></h3>
       <div className="groups">
         {groups}
       </div>

--- a/app/assets/javascripts/components/mark/index.cjsx
+++ b/app/assets/javascripts/components/mark/index.cjsx
@@ -127,10 +127,10 @@ module.exports = React.createClass # rename to Classifier
               }
               <HideOtherMarksButton active={@state.hideOtherMarks} onClick={@toggleHideOtherMarks} />
               { if onFirstAnnotation
-                <BadSubjectButton active={@state.badSubject} onClick={@toggleBadSubject} />
+                <BadSubjectButton label={"Bad " + @props.project.term('subject')} active={@state.badSubject} onClick={@toggleBadSubject} />
               }
               { if @state.badSubject
-                <p>You&#39;ve marked this subject as BAD. Thanks for flagging the issue! <strong>Press DONE to continue.</strong></p>
+                <p>You&#39;ve marked this {@props.project.term('subject')} as BAD. Thanks for flagging the issue! <strong>Press DONE to continue.</strong></p>
               }
               { if @state.hideOtherMarks
                 <p>Currently displaying only your marks. <strong>Toggle the button again to show all marks to-date.</strong></p>
@@ -160,9 +160,9 @@ module.exports = React.createClass # rename to Classifier
             </nav>
 
             {
-              if @getActiveWorkflow()?
+              if @getActiveWorkflow()? && @getWorkflowByName('transcribe')?
                 <p>
-                  <Link to="/transcribe/#{@getWorkflowByName('transcribe').id}/#{@getCurrentSubject().id}">Transcribe this page now!</Link>
+                  <Link to="/transcribe/#{@getWorkflowByName('transcribe').id}/#{@getCurrentSubject().id}">Transcribe this {@props.project.term('subject')} now!</Link>
                 </p>
             }
           </div>
@@ -172,13 +172,13 @@ module.exports = React.createClass # rename to Classifier
               <div className="explore">
                 <h2>Explore</h2>
                 <p>
-                  <Link to="/groups/#{@getCurrentSubjectSet().group_id}">About this logbook.</Link>
+                  <Link to="/groups/#{@getCurrentSubjectSet().group_id}">About this {@props.project.term('group')}.</Link>
                 </p>
               </div>
           }
 
           <div className="forum-holder">
-            <ForumSubjectWidget subject_set = @getCurrentSubjectSet() />
+            <ForumSubjectWidget subject_set={@getCurrentSubjectSet()} project={@props.project} />
           </div>
 
           <div className="social-media-container">

--- a/app/assets/javascripts/components/transcribe/index.cjsx
+++ b/app/assets/javascripts/components/transcribe/index.cjsx
@@ -112,7 +112,7 @@ module.exports = React.createClass # rename to Classifier
               header          = { if @state.userClassifiedAll then "Thanks for transcribing!" else "Nothing to transcribe" }
               buttons         = {<GenericButton label='Continue' href='/#/mark' />}
             >
-                Currently, there are no subjects to {@props.workflowName}. Try <a href="/#/mark">marking</a> instead!
+                Currently, there are no {@props.project.term('subject')}s to {@props.workflowName}. Try <a href="/#/mark">marking</a> instead!
             </DraggableModal>
 
           else if @getCurrentSubject()? and @getCurrentTask()?
@@ -164,7 +164,7 @@ module.exports = React.createClass # rename to Classifier
             <div className="task-area">
 
               <div className="forum-holder">
-                <ForumSubjectWidget subject=@getCurrentSubject() />
+                <ForumSubjectWidget subject=@getCurrentSubject() project={@props.project} />
               </div>
 
             </div>

--- a/app/assets/javascripts/components/transcribe/tools/text-tool/index.cjsx
+++ b/app/assets/javascripts/components/transcribe/tools/text-tool/index.cjsx
@@ -213,7 +213,7 @@ TextTool = React.createClass
         buttons.push <HelpButton onClick={@props.onShowHelp}/>
 
       if @props.onBadSubject?
-        buttons.push <BadSubjectButton active={@props.badSubject} onClick={@props.onBadSubject} />
+        buttons.push <BadSubjectButton label={"Bad mark"} active={@props.badSubject} onClick={@props.onBadSubject} />
 
       if @props.onIllegibleSubject?
         buttons.push <IllegibleSubjectButton active={@props.illegibleSubject} onClick={@props.onIllegibleSubject} />

--- a/app/assets/javascripts/components/verify/index.cjsx
+++ b/app/assets/javascripts/components/verify/index.cjsx
@@ -66,7 +66,7 @@ module.exports = React.createClass # rename to Classifier
               header          = { if @state.userClassifiedAll then "You verified them all!" else "Nothing to verify" }
               buttons         = {<GenericButton label='Continue' href='/#/mark' />}
             >
-                There are currently no {@props.workflowName} subjects. Try <a href="/#/mark">marking</a> instead!
+              Currently, there are no {@props.project.term('subject')}s to {@props.workflowName}. Try <a href="/#/mark">marking</a> instead!
             </DraggableModal>
 
           else if @getCurrentSubject()?
@@ -103,7 +103,7 @@ module.exports = React.createClass # rename to Classifier
               </div>
 
               <div className="forum-holder">
-                <ForumSubjectWidget subject_set=@getCurrentSubject() />
+                <ForumSubjectWidget subject=@getCurrentSubject() project={@props.project} />
               </div>
 
             </div>

--- a/app/assets/javascripts/models/project.coffee
+++ b/app/assets/javascripts/models/project.coffee
@@ -1,0 +1,10 @@
+class Project
+
+  constructor: (obj) ->
+    for k,v of obj
+      @[k] = v
+
+  term: (t) ->
+    @terms_map[t] ? t
+
+module.exports = Project

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -24,6 +24,7 @@ class Project
   field  :team_emails,       type: Array
   field  :metadata_search,   type: Hash
   field  :tutorial,          type: Hash
+  field  :terms_map,         type: Hash, default: {} # Hash mapping internal terms to project appropriate terms (e.g. 'group'=>'ship')
 
   include CachedStats
 

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -1,5 +1,5 @@
 class ProjectSerializer < ActiveModel::MongoidSerializer
-  attributes :id, :title, :short_title, :summary, :home_page_content, :organizations , :team, :pages, :logo, :background, :workflows, :forum, :tutorial, :feedback_form_url, :metadata_search, :current_user_tutorial
+  attributes :id, :title, :short_title, :summary, :home_page_content, :organizations , :team, :pages, :logo, :background, :workflows, :forum, :tutorial, :feedback_form_url, :metadata_search, :current_user_tutorial, :terms_map
   has_many :workflows
 
   delegate :current_or_guest_user, to: :scope

--- a/project/emigrant/project.json
+++ b/project/emigrant/project.json
@@ -5,6 +5,11 @@
   "background": "assets/emigrant/background.jpg",
   "admin_email": "paulbeaudoin@nypl.org",
   "logo": "/assets/emigrant/logo.svg",
+  "terms_map": {
+    "group": "collection",
+    "subject set": "page",
+    "subject": "page"
+  },
   "team_emails": [
     "brianfoo@nypl.org",
     "contact@paulbeaudoin.com",


### PR DESCRIPTION
Allows project admin to configure appropriate terms for what we internally refer to as groups, subject-sets, and subjects. Translation applied anywhere those internal terms are exposed on the front end (although I may have missed some places). This can be complement full i18n later