### PR TITLE
adding support for examples array in task config

### DIFF
--- a/app/assets/javascripts/components/transcribe/tools/composite-tool/index.cjsx
+++ b/app/assets/javascripts/components/transcribe/tools/composite-tool/index.cjsx
@@ -22,22 +22,23 @@ CompositeTool = React.createClass
     task: null
     subject: null
 
-  # componentWillReceiveProps: (new_props) ->
-  #   @setState annotation: new_props
-
   # this can go into a mixin? (common across all transcribe tools)
-  # DUPE in text-tool:
   getPosition: (data) ->
+    return x: null, y: null if ! data.x?
+
+    yPad = 20
     switch data.toolName
       when 'rectangleTool'
         x = data.x
-        y = parseFloat(data.y) + parseFloat(data.height)
+        y = parseFloat(data.y) + parseFloat(data.height) + yPad
       when 'textRowTool'
         x = data.x
-        y = data.yLower
+        y = data.yLower + yPad
       else # default for pointTool
         x = data.x
-        y = data.y
+        y = data.y + yPad if data.y?
+    x = @props.subject.width / 2 if ! x?
+    y = @props.subject.height / 2 if ! y?
     return {x,y}
 
   onViewerResize: (size) ->
@@ -116,6 +117,7 @@ CompositeTool = React.createClass
       >
 
       <label>{@props.task.instruction}</label>
+
       {
         for sub_tool in @props.task.tool_config.options
           ToolComponent = @props.transcribeTools[sub_tool.tool]

--- a/app/assets/javascripts/components/transcribe/tools/text-tool/index.cjsx
+++ b/app/assets/javascripts/components/transcribe/tools/text-tool/index.cjsx
@@ -171,11 +171,23 @@ TextTool = React.createClass
 
     ref = @props.ref || "input0"
 
+    # Grab examples either from examples in top level of task or (for composite tool) inside this field's option hash:
+    examples = @props.task.examples ? ( t for t in (@props.task.tool_config?.options ? []) when t.value==@props.annotation_key )[0]?.examples
+
     # create component input field(s)
     tool_content =
       <div className="input-field active">
 
         <label dangerouslySetInnerHTML={{__html: marked( label ) }} />
+
+        { if examples
+          <ul className="task-examples">
+          { for ex in examples
+              <li>{ex}</li>
+          }
+          </ul>
+        }
+
         {
           atts =
             ref: ref

--- a/app/assets/stylesheets/components/transcribe/transcribe-tool.styl
+++ b/app/assets/stylesheets/components/transcribe/transcribe-tool.styl
@@ -1,6 +1,7 @@
 .transcribe-tool
   position absolute
   min-width 200px
+  max-width 500px
   background-color rgba(255,255,255,0.75)
   box-shadow 0 0 5px 3px rgba(0,0,0,.4)
   border-radius 6px
@@ -28,6 +29,26 @@
         text-align left
         cursor move
         font-size 20px
+
+        // passing task labels through marked creates a root <p> tag
+        p
+          margin 0
+
+      .task-examples
+        list-style none
+        margin 10px 0
+        padding-left 0
+
+        li
+          display inline-block
+          padding-left 0.8em 
+          font-style italic
+
+          &:before, &:after
+            content '"'
+
+      .task-examples:before
+        content 'e.g.'
 
       input
         outline none
@@ -72,6 +93,9 @@
           clear left
           padding-top 0.8em
           line-height 1.4em
+
+        .task-examples
+          margin 0
 
   .button
     outline none

--- a/app/models/workflow_task.rb
+++ b/app/models/workflow_task.rb
@@ -9,6 +9,7 @@ class WorkflowTask
   field    :tool_config,                             type: Hash
   field    :next_task,                               type: String
   field    :help,                                    type: Hash
+  field    :examples,                                type: Array
 
   embedded_in :workflow
 

--- a/app/serializers/workflow_task_serializer.rb
+++ b/app/serializers/workflow_task_serializer.rb
@@ -1,4 +1,4 @@
 class WorkflowTaskSerializer < ActiveModel::MongoidSerializer
-  attributes :key, :tool_config, :instruction, :next_task, :generates_subject_type, :tool, :help
+  attributes :key, :tool_config, :instruction, :next_task, :generates_subject_type, :tool, :help, :examples
 
 end

--- a/lib/tasks/load_project.rake
+++ b/lib/tasks/load_project.rake
@@ -157,7 +157,7 @@ desc 'creates a poject object from the project directory'
     
     # In Pick-one-mark-one and compositeTool, rename 'tools' to 'options'
     if ['pickOneMarkOne', 'compositeTool'].include? task_hash[:tool]
-      config[:options] = config.delete :tools
+      config[:options] = config.delete :tools if config[:options].nil?
     end
 
     # In Pick-one and compositeTool, structure 'options' as an array rather than a hash:

--- a/project/emigrant/content/help/learn_marking.md
+++ b/project/emigrant/content/help/learn_marking.md
@@ -1,0 +1,5 @@
+Select a label, draw a rectangle around all instaces of that variable on the image. No need to mark an area twice. 
+You will see other people's rectangles on the image. We hope this will help us get more complete transcription and repsect your time.
+
+
+

--- a/project/emigrant/content/help/learn_marking.md
+++ b/project/emigrant/content/help/learn_marking.md
@@ -1,5 +1,9 @@
-Select a label, draw a rectangle around all instaces of that variable on the image. No need to mark an area twice. 
-You will see other people's rectangles on the image. We hope this will help us get more complete transcription and repsect your time.
+#Hi!
 
+Your task is to identify fields in a series of bank records.
+
+Use the menu on the right to select a field (e.g. "Record Date"). Then, use your mouse to draw a box on the image around each place that the field appears.
+
+If a box has already been created, you don't need to draw it again.
 
 

--- a/project/emigrant/content/help/learn_transcribing.md
+++ b/project/emigrant/content/help/learn_transcribing.md
@@ -1,1 +1,1 @@
-Transcribe the text exactly as you see it and to the best of your ability.
+Later on, in the Transcribe task, you'll have a chance to transcribe the regions you've identified.

--- a/project/emigrant/content/help/learn_transcribing.md
+++ b/project/emigrant/content/help/learn_transcribing.md
@@ -1,0 +1,1 @@
+Transcribe the text exactly as you see it and to the best of your ability.

--- a/project/emigrant/tutorial/tutorial.json
+++ b/project/emigrant/tutorial/tutorial.json
@@ -1,0 +1,27 @@
+{
+    "name": "Tutorial",
+    "first_task": "learn_marking",
+    "tasks": {
+        "learn_marking": {
+            "next_task": "learn_transcribing",
+            "help": {
+                "title": "Learn To Mark",
+                "file": "learn_marking"
+            }
+        },
+        "learn_transcribing": {
+            "next_task": "another_task",
+            "help": {
+                "title": "Learn To Transcribe",
+                "file": "learn_transcribing"
+            }
+        },
+        "another_task": {
+            "next_task": null,
+            "help": {
+                "title": "Learn To Mark",
+                "file": "learn_marking"
+            }
+        }
+    }
+}

--- a/project/emigrant/tutorial/tutorial.json
+++ b/project/emigrant/tutorial/tutorial.json
@@ -5,22 +5,15 @@
         "learn_marking": {
             "next_task": "learn_transcribing",
             "help": {
-                "title": "Learn To Mark",
+                "title": "Marking Regions",
                 "file": "learn_marking"
             }
         },
         "learn_transcribing": {
             "next_task": "another_task",
             "help": {
-                "title": "Learn To Transcribe",
+                "title": "Transcribing",
                 "file": "learn_transcribing"
-            }
-        },
-        "another_task": {
-            "next_task": null,
-            "help": {
-                "title": "Learn To Mark",
-                "file": "learn_marking"
             }
         }
     }

--- a/project/emigrant/workflows/mark.json
+++ b/project/emigrant/workflows/mark.json
@@ -17,7 +17,7 @@
       },
       "tool_config" : {
         "displays_transcribe_button": false,
-        "tools": [
+        "options": [
           {"type": "rectangleTool", "label": "Record Date", "color": "purple", "generates_subject_type": "em_record_date", "help": "The record date can generally be found in the upper left hand corner of the record. If multiple dates appear, draw a box around each."},
           {"type": "rectangleTool", "label": "Record Number", "color": "#FE5409", "generates_subject_type": "em_record_number", "help": "The record number can generally be found in the upper right hand corner of the record."}
         ]
@@ -34,7 +34,7 @@
       },
       "tool_config" : {
         "displays_transcribe_button": false,
-        "tools": [
+        "options": [
           {"type": "rectangleTool", "label": "Mortgager Name", "color": "red", "generates_subject_type": "em_record_mortgager", "help": "The mortgager name is often found at the top of the list of hand-entered data in the bottom half of the records. The mortgager tends to be a single person’s name. If multiple names are provided, draw one box around all of them."},
           {"type": "rectangleTool", "label": "Street Address", "color": "green", "generates_subject_type": "em_record_street_address", "help":"The street address is often found at the top of the list of hand-entered data in the bottom half of the records."},
           {"type": "rectangleTool", "label": "Amount Loaned", "color": "blue", "generates_subject_type": "em_record_amount_loaned", "help":"The amount loaned is typically found at or near the bottom of the record."}
@@ -52,7 +52,7 @@
       },
       "tool_config" : {
         "displays_transcribe_button": false,
-        "tools": [
+        "options": [
           {"type": "rectangleTool", "label": "Valuation", "color": "green", "generates_subject_type": "em_record_valuation", "help":"Some records include valuations comprised of an assessment date and a dollar value. These are hand-written and are typically found at or near the bottom of the record. If there are multiple valuations, draw one box around all of them."}
         ]
       },

--- a/project/emigrant/workflows/transcribe.json
+++ b/project/emigrant/workflows/transcribe.json
@@ -15,9 +15,10 @@
       "tool": "textTool",
       "tool_config": {},
       "instruction": "Enter the record date",
+      "examples": ["1867 May 11", "1867 July 30", "1875 December 31"],
       "help": {
         "title": "Record Date",
-        "body": "The record date can generally be found in the upper left hand corner of the record. Enter it as written, e.g. \"1867 May 11\""
+        "body": "The record date can generally be found in the upper left hand corner of the record."
       },
       "generates_subject_type": "em_transcribed_date"
     },
@@ -26,9 +27,10 @@
       "tool": "numberTool",
       "tool_config": {},
       "instruction": "Enter the record number",
+      "examples": ["287", "289"],
       "help": {
         "title": "Record Number",
-        "body": "The record number can generally be found in the upper right hand corner of the record. E.g. \"129\""
+        "body": "The record number can generally be found in the upper right hand corner of the record."
       },
       "generates_subject_type": "em_transcribed_record_number"
     },
@@ -39,6 +41,7 @@
         "suggest": "common"
       },
       "instruction": "Enter the mortgager's name",
+      "examples": ["John O'Meallia", "Trustees of St. Patrick's Cathedral"],
       "generates_subject_type": "em_transcribed_mortgager",
       "help": {
         "title": "Mortgager Name",
@@ -50,10 +53,11 @@
       "tool": "textTool",
       "tool_config": {},
       "instruction": "Enter the street address",
+      "examples": ["39 Mott St", "S. W. corner of 7th Avenue & 25th St. No 226 7th Avenue", "Mulberry, Mott and Prince St"],
       "generates_subject_type": "em_transcribed_address",
       "help": {
         "title": "Street Address",
-        "body": "The building address is sometimes labeled \"No. of Street or Avenue\". When possible, try to interpret the address given using contemporary address conventions. For example, for \"No. 39 Mott St\" enter \"39 Mott St\""
+        "body": "The building address is sometimes labeled \"No. of Street or Avenue\". When possible, try to interpret the address given using contemporary address conventions."
       }
     },
 
@@ -61,10 +65,11 @@
       "tool": "numberTool",
       "tool_config": {},
       "instruction": "Enter the Amount Loaned",
+      "examples": ["$4,500", "$50,000 and $30,000"],
       "generates_subject_type": "em_transcribed_amount_loaned",
       "help": {
         "title": "Amount Loaned",
-        "body": "The amount loaned is typically found at or near the bottom of the record. For example, for \"Amount Loaned: $4,500.\", enter \"4500\"."
+        "body": "The amount loaned is typically found at or near the bottom of the record."
       }
     },
 
@@ -74,11 +79,13 @@
         "tools": {
           "em_valuation_date": {
             "tool": "textTool",
+            "examples": ["1879 November"],
             "tool_config": {"suggest": "common"},
             "label": "Date"
           },
           "em_valuation_amount": {
             "tool": "textTool",
+            "examples": ["$200,000"],
             "tool_config": {},
             "label": "Amount"
           }


### PR DESCRIPTION
Allows admin to specify an `examples` property for tasks, which causes examples to appear above transcription input in Transcribe. E.g.:

```
      ...
       "instruction": "Enter the record date",
      "examples": ["1867 May 11", "1867 July 30", "1875 December 31"],
      "help":   
      ...
```