### PR TITLE
added /assets to Kievit font file path bc it was 404ing

### DIFF
--- a/project/emigrant/styles.css
+++ b/project/emigrant/styles.css
@@ -1,15 +1,15 @@
 /* Fonts */
 @font-face {
   font-family: 'Kievit';
-  src: url('/emigrant/KievitWeb-Book.eot'); /* IE9 Compat Modes */
-  src: url('/emigrant/KievitWeb-Book.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
-       url('/emigrant/KievitWeb-Book.woff') format('woff'); /* Pretty Modern Browsers */
+  src: url('/assets/emigrant/KievitWeb-Book.eot'); /* IE9 Compat Modes */
+  src: url('/assets/emigrant/KievitWeb-Book.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
+       url('/assets/emigrant/KievitWeb-Book.woff') format('woff'); /* Pretty Modern Browsers */
 }
 @font-face {
   font-family: 'Kievit';
-  src: url('/emigrant/KievitWeb-Medi.eot'); /* IE9 Compat Modes */
-  src: url('/emigrant/KievitWeb-Medi.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
-       url('/emigrant/KievitWeb-Medi.woff') format('woff'); /* Pretty Modern Browsers */
+  src: url('/assets/emigrant/KievitWeb-Medi.eot'); /* IE9 Compat Modes */
+  src: url('/assets/emigrant/KievitWeb-Medi.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
+       url('/assets/emigrant/KievitWeb-Medi.woff') format('woff'); /* Pretty Modern Browsers */
   font-weight: bold;
 }
 html, body,


### PR DESCRIPTION
Prepend emigrant font paths with /assets because rails4 static routing magic doesn't apply to assets in subfolders (?)