### PR TITLE
applying default mark size of 15

### DIFF
--- a/app/assets/javascripts/components/mark/tools/rectangle-tool/index.cjsx
+++ b/app/assets/javascripts/components/mark/tools/rectangle-tool/index.cjsx
@@ -1,4 +1,3 @@
-# @cjsx React.DOM
 React           = require 'react'
 Draggable       = require 'lib/draggable'
 DragHandle      = require './drag-handle'
@@ -26,8 +25,8 @@ module.exports = React.createClass
     defaultValues: ({x, y}) ->
       x: x
       y: y
-      width: MINIMUM_SIZE
-      height: MINIMUM_SIZE
+      width: 0
+      height: 0
 
     initStart: ({x,y}, mark) ->
       @initCoords = {x,y}
@@ -52,6 +51,13 @@ module.exports = React.createClass
 
     initValid: (mark) ->
       mark.width > MINIMUM_SIZE and mark.height > MINIMUM_SIZE
+
+    # This callback is called on mouseup to override mark properties (e.g. if too small)
+    initRelease: (coords, mark, e) ->
+      mark.width = Math.max mark.width, MINIMUM_SIZE
+      mark.height = Math.max mark.height, MINIMUM_SIZE
+      mark
+
 
   initCoords: null
 
@@ -115,7 +121,6 @@ module.exports = React.createClass
     @props.onChange e
 
   dragFilter: (key) ->
-    # console.log "dragFilter KEY", key
     if key == "handleLLDrag"
       return @handleLLDrag
     if key == "handleLHDrag"

--- a/app/assets/javascripts/components/mark/tools/rectangle-tool/index.cjsx
+++ b/app/assets/javascripts/components/mark/tools/rectangle-tool/index.cjsx
@@ -5,7 +5,7 @@ DragHandle      = require './drag-handle'
 DeleteButton    = require 'components/buttons/delete-mark'
 MarkButtonMixin = require 'lib/mark-button-mixin'
 
-MINIMUM_SIZE = 5
+MINIMUM_SIZE = 50
 DELETE_BUTTON_ANGLE = 45
 DELETE_BUTTON_DISTANCE_X = 12
 DELETE_BUTTON_DISTANCE_Y = 0
@@ -26,8 +26,8 @@ module.exports = React.createClass
     defaultValues: ({x, y}) ->
       x: x
       y: y
-      width: 0
-      height: 0
+      width: MINIMUM_SIZE
+      height: MINIMUM_SIZE
 
     initStart: ({x,y}, mark) ->
       @initCoords = {x,y}
@@ -94,6 +94,11 @@ module.exports = React.createClass
       LY = y2
       HY = y1
 
+    # PB: L and H seem to denote Low and High values of x & y, so:
+    # LL: upper left
+    # HL: upper right
+    # HH: lower right
+    # LH: lower left
     pointsHash = {
       handleLLDrag: [LX, LY],
       handleHLDrag: [HX, LY],
@@ -106,6 +111,7 @@ module.exports = React.createClass
     return if @props.disabled
     @props.mark.x += d.x / @props.xScale
     @props.mark.y += d.y / @props.yScale
+    @assertBounds()
     @props.onChange e
 
   dragFilter: (key) ->
@@ -121,8 +127,8 @@ module.exports = React.createClass
 
   handleLLDrag: (e, d) ->
     @props.mark.x += d.x / @props.xScale
-    @props.mark.y += d.y / @props.yScale
     @props.mark.width -= d.x / @props.xScale
+    @props.mark.y += d.y / @props.yScale
     @props.mark.height -= d.y / @props.yScale
     @props.onChange e
 
@@ -133,8 +139,8 @@ module.exports = React.createClass
     @props.onChange e
 
   handleHLDrag: (e, d) ->
-    @props.mark.y += d.y / @props.yScale
     @props.mark.width += d.x / @props.xScale
+    @props.mark.y += d.y / @props.yScale
     @props.mark.height -= d.y / @props.yScale
     @props.onChange e
 
@@ -142,6 +148,23 @@ module.exports = React.createClass
     @props.mark.width += d.x / @props.xScale
     @props.mark.height += d.y / @props.yScale
     @props.onChange e
+
+
+  assertBounds: ->
+    @props.mark.x = Math.min @props.sizeRect.props.width - @props.mark.width, @props.mark.x
+    @props.mark.y = Math.min @props.sizeRect.props.height - @props.mark.height, @props.mark.y
+
+    @props.mark.x = Math.max 0, @props.mark.x
+    @props.mark.y = Math.max 0, @props.mark.y
+
+    @props.mark.width = Math.max @props.mark.width, MINIMUM_SIZE
+    @props.mark.height = Math.max @props.mark.height, MINIMUM_SIZE
+
+  validVert: (y,h) ->
+    y >= 0 && y + h <= @props.sizeRect.props.height
+
+  validHoriz: (x,w) ->
+    x >= 0 && x + w <= @props.sizeRect.props.width
 
   getDeleteButtonPosition: ()->
     points = @state.pointsHash["handleHLDrag"]

--- a/app/assets/javascripts/components/mark/tools/rectangle-tool/index.cjsx
+++ b/app/assets/javascripts/components/mark/tools/rectangle-tool/index.cjsx
@@ -4,7 +4,7 @@ DragHandle      = require './drag-handle'
 DeleteButton    = require 'components/buttons/delete-mark'
 MarkButtonMixin = require 'lib/mark-button-mixin'
 
-MINIMUM_SIZE = 50
+MINIMUM_SIZE = 15
 DELETE_BUTTON_ANGLE = 45
 DELETE_BUTTON_DISTANCE_X = 12
 DELETE_BUTTON_DISTANCE_Y = 0

--- a/app/assets/javascripts/components/subject-viewer.cjsx
+++ b/app/assets/javascripts/components/subject-viewer.cjsx
@@ -20,12 +20,11 @@ module.exports = React.createClass
   mixins: [MarkDrawingMixin] # load helper methods to draw marks and highlights
 
   getInitialState: ->
-    imageWidth: @props.subject.width
-    imageHeight: @props.subject.height
     subject: @props.subject
     marks: @getMarksFromProps(@props)
     selectedMark: null
     active: @props.active
+    scale: {horizontal: 1, vertical: 1}
 
   getDefaultProps: ->
     tool: null # Optional tool to place alongside subject (e.g. transcription tool placed alongside mark)
@@ -39,31 +38,38 @@ module.exports = React.createClass
 
     @setState marks: @getMarksFromProps(new_props)
 
+    if new_props.subject.id == @props.subject.id
+      @scrollToSubject()
+
   componentDidMount: ->
     @setView 0, 0, @props.subject.width, @props.subject.height
     @loadImage @props.subject.location.standard
     window.addEventListener "resize", this.updateDimensions
 
+  scrollToSubject: ->
     # scroll to mark when transcribing
     if @props.workflow.name is 'transcribe'
-      yPos = (@props.subject.data.y - @props.subject.data.height?) * @getScale().vertical - 100
-      $('html, body').animate({scrollTop: yPos}, 500)
+      yPos = (@props.subject.data.y - @props.subject.data.height?) * @state.scale.vertical - 100
+      $('html, body').stop().animate({scrollTop: yPos}, 500)
+
+  componentDidUpdate: ->
+    scale = @getScale()
+    changed = scale.horizontal != @state.scale.horizontal && scale.vertical != @state.scale.vertical
+    if changed
+      @setState scale: scale, () =>
+        @updateDimensions()
+        @scrollToSubject()
 
   componentWillUnmount: ->
-    window.removeEventListener "resize", this.updateDimensions
+    window.removeEventListener "resize", @updateDimensions
 
   updateDimensions: ->
-    @setState
-      windowInnerWidth: window.innerWidth
-      windowInnerHeight: window.innerHeight
-
-    if ! @state.loading && @getScale()? && @props.onLoad?
-      scale = @getScale()
+    if ! @state.loading && @state.scale? && @props.onLoad?
+      scale = @state.scale
       props =
         size:
           w: scale.horizontal * @props.subject.width
           h: scale.vertical * @props.subject.height
-          scale: scale
 
       @props.onLoad props
 
@@ -72,14 +78,12 @@ module.exports = React.createClass
       img = new Image()
       img.src = url
       img.onload = =>
-        # if @isMounted()
-
         @setState
           url: url
-          # imageWidth: img.width
-          # imageHeight: img.height
           loading: false
-        @updateDimensions()
+          scale: @getScale(), () =>
+            @updateDimensions()
+            @scrollToSubject()
 
   # VARIOUS EVENT HANDLERS
 
@@ -181,6 +185,7 @@ module.exports = React.createClass
   # PB This is not returning anything but 0, 0 for me; Seems like @refs.sizeRect is empty when evaluated (though nonempty later)
   getScale: ->
     rect = @refs.sizeRect?.getDOMNode().getBoundingClientRect()
+
     return {horizontal: 1, vertical: 1} if ! rect? || ! rect.width?
     rect ?= width: 0, height: 0
     horizontal = rect.width / @props.subject.width
@@ -193,7 +198,7 @@ module.exports = React.createClass
 
   getEventOffset: (e) ->
     rect = @refs.sizeRect.getDOMNode().getBoundingClientRect()
-    scale = @getScale()
+    scale = @state.scale # @getScale()
     x = ((e.pageX - pageXOffset - rect.left) / scale.horizontal) + @state.viewX
     y = ((e.pageY - pageYOffset - rect.top) / scale.vertical) + @state.viewY
     return {x, y}
@@ -267,7 +272,8 @@ module.exports = React.createClass
 
   renderMarks: (marks) ->
     return unless marks.length > 0
-    scale = @getScale()
+    # scale = @getScale()
+    scale = @state.scale
 
     marksToRender = for mark in marks
       mark._key ?= Math.random()
@@ -315,7 +321,7 @@ module.exports = React.createClass
     return null if ! @props.active
 
     viewBox = [0, 0, @props.subject.width, @props.subject.height]
-    scale = @getScale()
+    scale = @state.scale # @getScale()
 
     # marks = @getCurrentMarks()
     marks = @state.marks

--- a/app/assets/javascripts/components/subject-viewer.cjsx
+++ b/app/assets/javascripts/components/subject-viewer.cjsx
@@ -174,7 +174,6 @@ module.exports = React.createClass
     @setUncommittedMark mark
 
   setUncommittedMark: (mark) ->
-    # console.log 'setUncommittedMark(): ', mark
     @setState
       uncommittedMark: mark,
       selectedMark: mark #, => @forceUpdate() # not sure if this is needed?


### PR DESCRIPTION
 - default size of marks now 50 ( https://github.com/zooniverse/scribeAPI/issues/328 )
 - prevent dragging marks off image (altough handle-drags still unbounded)
 - reworked getScale and scrollTo code to remove browser warnings about calling getDomNode from within render in subj viewer