### PR TITLE
fixing overzealous fetchPosts from forum subject widget

### DIFF
--- a/app/assets/javascripts/components/forum-connectors/discourse-connector.cjsx
+++ b/app/assets/javascripts/components/forum-connectors/discourse-connector.cjsx
@@ -25,7 +25,7 @@ module.exports =
             title: p.blurb
             excerpt: p.blurb
             author: p.username
-            url: base_url + '/t/' + p.slug
+            url: base_url + '/t/' + p.topic_slug
             updated_at: p.updated_at
           resp = {}
           resp[type ? 'subjects'] = posts

--- a/app/assets/javascripts/components/subject-set-toolbar.cjsx
+++ b/app/assets/javascripts/components/subject-set-toolbar.cjsx
@@ -8,7 +8,7 @@ ForumSubjectWidget            = require './forum-subject-widget'
 module.exports = React.createClass
   displayName: "SubjectSetToolbar"
 
-  propTypes: 
+  propTypes:
     hideOtherMarks: React.PropTypes.bool.isRequired
 
   getInitialState: ->
@@ -16,9 +16,6 @@ module.exports = React.createClass
     zoomPanViewBox: @props.viewBox
     active_pane: ''
     hideMarks: true
-
-  componentDidMount: ->
-    window.addEventListener "keydown", (e) => @_handleZoomKeys(e)
 
   togglePane: (name) ->
     if @state.active_pane == name


### PR DESCRIPTION
Primarily fixes the fetchPosts bug but also a couple minor things like linking to the right post and removing that old handleZoomKeys call that somehow wandered into the toolbar