### PR TITLE
Remove project:load from start.sh

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -14,6 +14,4 @@ then
     source $env_configs
 fi
 
-rake project:load[$1]
-
 exec bundle exec rails server -p 80


### PR DESCRIPTION
There's no need to run this every time the app starts; we can just run it manually as needed.

Note that I've already cherry-picked this change into anzac-production and old-weather-whaling-production so that we can get it live immediately.