### PR TITLE
more indexes on belongs_tos, etc

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -8,13 +8,14 @@ class GroupsController < ApplicationController
     limit         = get_int :limit, 25
     project_id    = get_objectid :project_id
 
-    # @groups = Group.all
-
     # If project_id given (it always should be), filter on it:
-    # if ! project_id.nil?
-     #  @groups = @groups.by_project project_id
-    # end
-    @groups = Project.current.groups
+    if ! project_id.nil?
+      @groups = Group.by_project project_id
+
+    # Otherwise, return current project's groups:
+    else
+      @groups = Project.current.groups
+    end
 
     # Apply pagination:
     @groups = @groups.page(page).per(limit)

--- a/app/models/favourite.rb
+++ b/app/models/favourite.rb
@@ -4,4 +4,6 @@ class Favourite
   belongs_to :subject
   belongs_to :user
   validates_uniqueness_of :user_id, scope: :subject_id , message: "this user has already favourited this subject"
+
+  index user_id: 1, subject_id: 1
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -87,11 +87,11 @@ class Project
 
     # retrieve subject data
     subjects_data = []
-    subject_groups = Subject.all.group_by {|d| d.status}
-    subject_groups.each do |status, subjects|
+    subject_groups = Subject.group_by_field :status
+    subject_groups.each do |(status, count)|
       subjects_data << {
         label: status,
-        value: subjects.size
+        value: count
       }
     end
 

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -23,6 +23,8 @@ class Workflow
 
   embeds_many :tasks, class_name: 'WorkflowTask'
 
+  index project_id: 1, name: 1
+
   def subject_has_enough_classifications(subject)
     subject.classification_count >= self.generates_subjects_after
   end

--- a/lib/tasks/project.rake
+++ b/lib/tasks/project.rake
@@ -196,6 +196,8 @@ namespace :project do
     # Make sure various subject indexes exist:
     Subject.create_indexes
     Group.create_indexes
+    Workflow.create_indexes
+    Favourite.create_indexes
 
     project.save
     project


### PR DESCRIPTION
- Adds Workflow and Favourite indexes for common belongs_to queries. (even though we're not really favouriting things yet)
- Pushes group_by work in Project#calc_stats to db where it belongs (previously pulled all subjects from db and manually grouped)