### PR TITLE
Add support for workflow-specific tutorials (#330)

### DIFF
--- a/app/assets/javascripts/components/mark/index.cjsx
+++ b/app/assets/javascripts/components/mark/index.cjsx
@@ -303,7 +303,12 @@ module.exports = React.createClass # rename to Classifier
         </div>
       </div>
       { if @props.project.tutorial? && @state.showingTutorial
-        <Tutorial tutorial={@props.project.tutorial} onCloseTutorial={@props.onCloseTutorial} />
+          # Check for workflow-specific tutorial
+          if @props.project.tutorial.workflows? && @props.project.tutorial.workflows[@getActiveWorkflow()?.name]
+            <Tutorial tutorial={@props.project.tutorial.workflows[@getActiveWorkflow().name]} onCloseTutorial={@props.onCloseTutorial} />
+          # Otherwise just show general tutorial
+          else
+            <Tutorial tutorial={@props.project.tutorial} onCloseTutorial={@props.onCloseTutorial} />
       }
       { if @state.helping
         <HelpModal help={@getCurrentTask().help} onDone={=> @setState helping: false } />

--- a/app/assets/javascripts/components/transcribe/index.cjsx
+++ b/app/assets/javascripts/components/transcribe/index.cjsx
@@ -19,6 +19,7 @@ RowFocusTool            = require '../row-focus-tool'
 API                     = require '../../lib/api'
 
 HelpModal               = require 'components/help-modal'
+Tutorial                = require 'components/tutorial'
 DraggableModal          = require 'components/draggable-modal'
 GenericButton           = require 'components/buttons/generic-button'
 
@@ -33,7 +34,7 @@ module.exports = React.createClass # rename to Classifier
     subject_index:                0
     helping:                      false
     last_mark_task_key:           @props.query.mark_key
-
+    showingTutorial:              false
 
   getDefaultProps: ->
     workflowName: 'transcribe'
@@ -79,6 +80,12 @@ module.exports = React.createClass # rename to Classifier
   toggleHelp: ->
     @setState helping: not @state.helping
 
+  toggleTutorial: ->
+    @setState showingTutorial: not @state.showingTutorial
+
+  hideTutorial: ->
+    @setState showingTutorial: false
+
   componentWillUnmount:->
     not @state.badSubject
 
@@ -111,7 +118,7 @@ module.exports = React.createClass # rename to Classifier
     <div className="classifier">
       <div className="subject-area">
         {
-          unless @getCurrentSubject() || @state.noMoreSubjects 
+          unless @getCurrentSubject() || @state.noMoreSubjects
             <DraggableModal
               header          = { "Loading transcription subjects." }
               buttons         = {<GenericButton label='Back to Marking' href='/#/mark' />}
@@ -128,7 +135,7 @@ module.exports = React.createClass # rename to Classifier
                 Currently, there are no {@props.project.term('subject')}s for you to {@props.workflowName}. Try <a href="/#/mark">marking</a> instead!
             </DraggableModal>
 
-          
+
           else if @getCurrentSubject()? and @getCurrentTask()?
 
             <SubjectViewer
@@ -177,14 +184,34 @@ module.exports = React.createClass # rename to Classifier
               @getCurrentTask().next_task
 
           <div className="right-column">
-            <div className="task-area">
+            <div className="task-area transcribe">
 
-              <div className="forum-holder">
-                <ForumSubjectWidget subject=@getCurrentSubject() project={@props.project} />
+              <div className="task-secondary-area">
+
+                {
+                  if @getCurrentTask()?
+                    <p>
+                      <a className="tutorial-link" onClick={@toggleTutorial}>View A Tutorial</a>
+                    </p>
+                }
+
+                <div className="forum-holder">
+                  <ForumSubjectWidget subject=@getCurrentSubject() project={@props.project} />
+                </div>
+
               </div>
 
             </div>
           </div>
+      }
+
+      { if @props.project.tutorial? && @state.showingTutorial
+          # Check for workflow-specific tutorial
+          if @props.project.tutorial.workflows? && @props.project.tutorial.workflows[@getActiveWorkflow()?.name]
+            <Tutorial tutorial={@props.project.tutorial.workflows[@getActiveWorkflow().name]} onCloseTutorial={@hideTutorial} />
+          # Otherwise just show general tutorial
+          else
+            <Tutorial tutorial={@props.project.tutorial} onCloseTutorial={@hideTutorial} />
       }
 
       { if @state.helping

--- a/app/assets/stylesheets/classify.styl
+++ b/app/assets/stylesheets/classify.styl
@@ -67,7 +67,7 @@
       border-radius 5px
       border-top-right-radius 0px
       border-bottom-right-radius 0px
-      z-index: 50;
+      z-index 50
 
       &.mark
         padding 20px 20px 0
@@ -287,6 +287,11 @@
                 &:before
                   color #3f5765
 
+      &.transcribe,
+      &.verify
+        .task-secondary-area
+          margin-bottom 0
+          border-bottom solid #999 1px
 
       .social-media-container
         margin 10px 0 -10px

--- a/project/emigrant/assets/css/styles.css
+++ b/project/emigrant/assets/css/styles.css
@@ -348,3 +348,6 @@ div.home-page {
 .classifier .right-column .task-area .workflow-task .answer.active {
   border-color: #3f5765;
 }
+.classifier .right-column .task-area .help-bad-subject-holder .task-help-button {
+  display: none;
+}

--- a/project/emigrant/tutorial/tutorial.json
+++ b/project/emigrant/tutorial/tutorial.json
@@ -23,5 +23,46 @@
                 "file": "learn_verifying"
             }
         }
+    },
+    "workflows": {
+      "mark": {
+        "name": "Mark Tutorial",
+        "first_task": "learn_marking",
+        "tasks": {
+          "learn_marking": {
+              "next_task": null,
+              "help": {
+                  "title": "Marking Regions",
+                  "file": "learn_marking"
+              }
+          }
+        }
+      },
+      "transcribe": {
+        "name": "Transcribe Tutorial",
+        "first_task": "learn_transcribing",
+        "tasks": {
+          "learn_transcribing": {
+              "next_task": null,
+              "help": {
+                  "title": "Transcribing Fields",
+                  "file": "learn_transcribing"
+              }
+          }
+        }
+      },
+      "verify": {
+        "name": "Verify Tutorial",
+        "first_task": "learn_verifying",
+        "tasks": {
+          "learn_verifying": {
+              "next_task": null,
+              "help": {
+                  "title": "Verifying Fields",
+                  "file": "learn_verifying"
+              }
+          }
+        }
+      }
     }
 }


### PR DESCRIPTION
I added the ability to have workflow-specific tutorials. In the tutorial config, I added a key called "workflows" that can contain workflow keys (i.e. "mark", "transcribe", "verify"). Each can contain a hash that is in the same format as the existing tutorial hash.

If a tutorial hash exists for a given workflow, it will override the default tutorial for that workflow.  If no workflow tutorial hash exists for a workflow, the default tutorial will display.  Thus, the change is backwards compatible for any existing tutorial config.

I also added the ability to invoke the tutorial on the transcribe page (it currently does not exist)