### PR TITLE
interim marks

### DIFF
--- a/app/assets/javascripts/components/mark/index.cjsx
+++ b/app/assets/javascripts/components/mark/index.cjsx
@@ -222,6 +222,7 @@ module.exports = React.createClass # rename to Classifier
               toggleHideOtherMarks={@toggleHideOtherMarks}
               currentSubtool={currentSubtool}
               lightboxHelp={@toggleLightboxHelp}
+              interimMarks={@state.interimMarks}
             />
         }
       </div>

--- a/app/assets/javascripts/components/mark/tools/rectangle-tool/index.cjsx
+++ b/app/assets/javascripts/components/mark/tools/rectangle-tool/index.cjsx
@@ -198,6 +198,7 @@ module.exports = React.createClass
   render: ->
     classes = []
     classes.push 'transcribable' if @props.isTranscribable
+    classes.push 'interim' if @props.interim
     classes.push if @props.disabled then 'committed' else 'uncommitted'
     classes.push "tanscribing" if @checkLocation()
 

--- a/app/assets/javascripts/components/subject-set-viewer.cjsx
+++ b/app/assets/javascripts/components/subject-set-viewer.cjsx
@@ -91,6 +91,7 @@ module.exports = React.createClass
         hideOtherMarks={@props.hideOtherMarks}
         currentSubtool={@props.currentSubtool}
         viewBox={@state.zoomPanViewBox}
+        interimMarks={@props.interimMarks}
       />
 
     </div>

--- a/app/assets/javascripts/components/subject-viewer.cjsx
+++ b/app/assets/javascripts/components/subject-viewer.cjsx
@@ -35,6 +35,7 @@ module.exports = React.createClass
     tool: null # Optional tool to place alongside subject (e.g. transcription tool placed alongside mark)
     onLoad: null
     annotationIsComplete: false
+    interimMarks: {}
 
   componentWillReceiveProps: (new_props) ->
     @setUncommittedMark null if new_props.task?.tool != 'pickOneMarkOne'
@@ -271,12 +272,16 @@ module.exports = React.createClass
     marks = []
     currentSubtool = props.currentSubtool
     for child_subject, i in props.subject.child_subjects
+      continue if ! child_subject?
       marks[i] = child_subject.region
       marks[i].subject_id = child_subject.id # child_subject.region.subject_id = child_subject.id # copy id field into region (not ideal)
       marks[i].isTranscribable = !child_subject.user_has_classified && child_subject.status != "retired"
       marks[i].belongsToUser = child_subject.belongs_to_user
       marks[i].groupActive = currentSubtool?.generates_subject_type == child_subject.type
       marks[i].user_has_deleted = child_subject.user_has_deleted
+
+    # Also present visible 'interim mark's for this subject:
+    marks.push(m) for m in (@props.interimMarks ? []) when m.show && m.subject_id == props.subject.id
 
     marks
 
@@ -319,7 +324,9 @@ module.exports = React.createClass
             xScale={scale.horizontal}
             yScale={scale.vertical}
             disabled={! mark.userCreated}
+            disabled={! mark.userCreated}
             isTranscribable={mark.isTranscribable}
+            interim={mark.interim_id?}
             isPriorMark={isPriorMark}
             subjectCurrentPage={@props.subjectCurrentPage}
             selected={mark is @state.selectedMark}

--- a/app/assets/stylesheets/components/mark/rectangle-tool.styl
+++ b/app/assets/stylesheets/components/mark/rectangle-tool.styl
@@ -33,6 +33,9 @@
       stroke rgb(67, 187, 253)
       stroke-opacity 1
 
+    &.interim
+      opacity 0.35
+
     // mark is committed and uneditable
     &.committed
       cursor default


### PR DESCRIPTION
Adds ‘interim mark’ to subject viewer while waiting for mark subject to be generated so that user gets visual reinforcement that we’re doing something. SVG el has class ‘interim’ which is currently styled w/ opacity 0.35, but we could conceivably make interim marks even more visually distinct from active and committed marks (e.g. spinner overly, animated dashed stroke, etc.)