### PR TITLE
Issue 479 no self votes

### DIFF
--- a/app/controllers/subjects_controller.rb
+++ b/app/controllers/subjects_controller.rb
@@ -39,6 +39,12 @@ class SubjectsController < ApplicationController
 
       # If user/guest active, filter out anything already classified:
       @subjects = @subjects.user_has_not_classified user.id.to_s if ! user.nil?
+
+      # Should we filter out subjects that the user herself created?
+      if ! user.nil? && ! (workflow = Workflow.find(workflow_id)).nil? && ! workflow.subjects_classifiable_by_creator
+        # Note: creating_user_ids are stored as ObjectIds, so no need to filter on user.id.to_s:
+        @subjects = @subjects.user_did_not_create user.id if ! user.nil?
+      end
     end
 
     links = {

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -18,6 +18,7 @@ class Subject
   scope :by_parent_subject, -> (parent_subject_id) { where(parent_subject_id: parent_subject_id) }
   scope :by_group, -> (group_id) { where(group_id: group_id) }
   scope :user_has_not_classified, -> (user_id) { where(:classifying_user_ids.ne => user_id)  }
+  scope :user_did_not_create, -> (user_id) { where(:creating_user_ids.ne => user_id)  }
 
   # This is a hash with one entry per deriv; `standard', 'thumbnail', etc
   field :location,                    type: Hash
@@ -49,7 +50,8 @@ class Subject
 
   # Denormalized array of user ids that have classified this subject for quick filtering
   field :classifying_user_ids,        type: Array, default: []
-  field :deleting_user_ids,        type: Array, default: []
+  field :deleting_user_ids,           type: Array, default: []
+  field :creating_user_ids,           type: Array, default: []
 
   belongs_to :workflow
   belongs_to :group

--- a/app/models/subject_generation_method.rb
+++ b/app/models/subject_generation_method.rb
@@ -50,7 +50,7 @@ class SubjectGenerationMethod
 
     {
       parent_subject: classification.subject,
-      created_by_user_id: classification.user.id,
+      created_by_user_id: classification.user.id, # Note this doesn't work if mult users' classifications contribute to generating a single subject
       subject_set: classification.subject.subject_set,
       group_id: classification.subject.subject_set.group_id,
       workflow: workflow_for_new_subject,

--- a/app/models/subject_generation_methods/collect_unique.rb
+++ b/app/models/subject_generation_methods/collect_unique.rb
@@ -51,8 +51,13 @@ module SubjectGenerationMethods
         end
       end
 
-      # By the nature of task employing collect-unique (i.e. verify), we should add the authors of the submitted classifications to the generated subject so that they're not allowed to classify (i.e. not allowed to vote on their own transcription)
-      classification.child_subject.classifying_user_ids ||= []
+      # PB: At writing, only verify uses collect-unique. It's important that
+      # subjects generated from transcribe not be classifyable (i.e. voted upon)
+      # by any user submitting a transcription. We should probably support a 
+      # thus generated are not classifyable by classification authors.
+      atts[:creating_user_ids] = classification.child_subject.creating_user_ids
+      atts[:creating_user_ids] ||= []
+      classification.child_subject.creating_user_ids.push classification.user_id
 
       # puts "Saving atts to classification: #{atts.inspect}"
       classification.child_subject.update_attributes atts

--- a/app/models/subject_generation_methods/collect_unique.rb
+++ b/app/models/subject_generation_methods/collect_unique.rb
@@ -51,6 +51,9 @@ module SubjectGenerationMethods
         end
       end
 
+      # By the nature of task employing collect-unique (i.e. verify), we should add the authors of the submitted classifications to the generated subject so that they're not allowed to classify (i.e. not allowed to vote on their own transcription)
+      classification.child_subject.classifying_user_ids ||= []
+
       # puts "Saving atts to classification: #{atts.inspect}"
       classification.child_subject.update_attributes atts
 

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -14,6 +14,11 @@ class Workflow
   field    :generates_subjects_max,                          type: Integer
   field    :generates_subjects_method,                       type: String,    default: 'one-per-classification'
   field    :generates_subjects_agreement,                    type: Float,     default: 0.75
+  # Controls whether or not subjects in this workflow may be classified by same
+  # users who created the subjects. For example, verify workflows should make
+  # this `false` to prevent a user's transcriptions from being verified by same
+  # user:
+  field    :subjects_classifiable_by_creator,                type: Boolean,   default: true
   field    :active_subjects,                                 type: Integer,   default: 0
   field    :order,                                           type: Integer,   default: 0
 

--- a/project/emigrant/workflows/verify.json
+++ b/project/emigrant/workflows/verify.json
@@ -7,6 +7,7 @@
   "generates_subjects_after": 3,
   "generates_subjects_max": 10,
   "generates_subjects_agreement": 0.75,
+  "subjects_classifiable_by_creator": false,
 
   "tasks": {
 


### PR DESCRIPTION
In Verify, prevent serving subjects to users they had a hand in creating in Transcribe lest they just vote for their own transcription. New subjects_classifiable_by_creator workflow config option defaults to true, but should be set to false for Verify workflows. Note this new config option defaults to true, which was essentially the previous behavior, this should have no change on existing workflows.