### PR TITLE
Fix issue 508: Retired root subjects missing in Mark

### DIFF
--- a/app/assets/javascripts/lib/fetch-subject-sets-mixin.cjsx
+++ b/app/assets/javascripts/lib/fetch-subject-sets-mixin.cjsx
@@ -96,6 +96,7 @@ module.exports =
       page: page
       limit: limit
       type: 'root'
+      status: 'any'
 
     process_subjects = (subjs) =>
       sets[ind].subjects = subjs

--- a/app/controllers/subjects_controller.rb
+++ b/app/controllers/subjects_controller.rb
@@ -13,8 +13,13 @@ class SubjectsController < ApplicationController
     limit                 = get_int :limit, 10
     page                  = get_int :page, 1
     type                  = params[:type]
+    # `status` filter must be one of: 'active', 'any'
+    status                = ['active','any'].include?(params[:status]) ? params[:status] : 'active'
 
-    @subjects = Subject.active.page(page).per(limit)
+    @subjects = Subject.page(page).per(limit)
+
+    # Only active subjects?
+    @subjects = @subjects.active if status == 'active'
 
     # Filter by subject type (e.g. 'root')
     @subjects = @subjects.by_type(type) if type

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -69,9 +69,10 @@ class Subject
   # Index for typical query when fetching subjects for Transcribe/Verify:
   index({"status" => 1, "workflow_id" => 1, "classifying_user_ids" => 1}, {background: true})
   # Index for Marking by subject set:
-  index({"status" => 1, "type" => 1, "subject_set_id" => 1}, {background: true})
+  index({"type" => 1, "subject_set_id" => 1}, {background: true})
   # Index for fetching child subjects for a parent subject, optionally filtering by region NOT NULL
   index({parent_subject_id: 1, status: 1, region: 1})
+  
 
   def thumbnail
     location['thumbnail'].nil? ? location['standard'] : location['thumbnail']


### PR DESCRIPTION
Fixing https://github.com/zooniverse/scribeAPI/issues/508 adds status filter to subjects endpoint, which defaults to ‘active’. If set to ‘any’ by Mark workflow fetch-subjects call, we get all root subjects regardless of status. The possible statuses for root subjects are active, retired, and bad, all of which should be shown when presenting at the subjects of a subject-set in Mark.