### PR TITLE
Menus config

### DIFF
--- a/app/assets/javascripts/components/app.cjsx
+++ b/app/assets/javascripts/components/app.cjsx
@@ -74,6 +74,7 @@ App = React.createClass
           pages={project.pages}
           short_title={project.short_title}
           logo={project.logo}
+          menus={project.menus}
           user={@state.user}
           loginProviders={@state.loginProviders}
         />
@@ -82,7 +83,7 @@ App = React.createClass
           <BrowserWarning />
           <RouteHandler hash={window.location.hash} project={project} onCloseTutorial={@setTutorialComplete} user={@state.user}/>
         </div>
-        <Footer privacyPolicy={ project.privacy_policy }/>
+        <Footer privacyPolicy={ project.privacy_policy } menus={project.menus} />
       </div>
     </div>
 

--- a/app/assets/javascripts/components/app.cjsx
+++ b/app/assets/javascripts/components/app.cjsx
@@ -83,7 +83,7 @@ App = React.createClass
           <BrowserWarning />
           <RouteHandler hash={window.location.hash} project={project} onCloseTutorial={@setTutorialComplete} user={@state.user}/>
         </div>
-        <Footer privacyPolicy={ project.privacy_policy } menus={project.menus} />
+        <Footer privacyPolicy={ project.privacy_policy } menus={project.menus} partials={project.partials} />
       </div>
     </div>
 

--- a/app/assets/javascripts/partials/footer.cjsx
+++ b/app/assets/javascripts/partials/footer.cjsx
@@ -42,11 +42,13 @@ Footer = React.createClass
                   <a href={item.url}>{item.label}</a>
                 </div>
             else
-              <div className="scribe-footer-category half">
-                <a href={@props.privacyPolicy}>Privacy Policy</a>
-              </div>
-              <div className="scribe-footer-category half">
-                <a href="https://github.com/zooniverse/ScribeAPI">Source & Bugs</a>
+              <div>
+                <div className="scribe-footer-category">
+                  <a href={@props.privacyPolicy}>Privacy Policy</a>
+                </div>
+                <div className="scribe-footer-category">
+                  <a href="https://github.com/zooniverse/ScribeAPI">Source & Bugs</a>
+                </div>
               </div>
           }
         </div>
@@ -54,15 +56,10 @@ Footer = React.createClass
 
       </div>
 
-      <div className="scribe-footer-credits">
-        <div>
-          <p>A collaboration between
-            <a href="http://www.nypl.org/collections/labs"><img src="/assets/nypllabs_logo.png" className="inline" alt="New York Public Library Labs" title="New York Public Library Labs" /></a>
-            and <a href="https://www.zooniverse.org/"><img src="/assets/zooniverse_logo.png" className="inline" alt="Zooniverse" title="Zooniverse" /></a>
-            with generous support from:</p>
-          <p><a href="http://www.neh.gov/"><img src="/assets/neh_logo.png" alt="National Endowment for the Humanities" title="National Endowment for the Humanities" /></a></p>
-        </div>
-      </div>
+      {
+        if @props.partials? && @props.partials["footer"]?
+          <div className="custom-footer" dangerouslySetInnerHTML={{__html: marked(@props.partials["footer"])}} />
+      }
 
     </div>
 

--- a/app/assets/javascripts/partials/footer.cjsx
+++ b/app/assets/javascripts/partials/footer.cjsx
@@ -16,7 +16,7 @@ Footer = React.createClass
       </a>
 
       <div className="scribe-footer-content">
-        <div className="scribe-footer-heading">This project is built using Scribe, a framework for crowdsourcing the transcription of text-based documents.</div>
+        <div className="scribe-footer-heading">This project is built using Scribe: Document transcription, crowdsourced</div>
 
         {if @state.categories?
           <div className="scribe-footer-projects">
@@ -35,13 +35,20 @@ Footer = React.createClass
         }
 
         <div className="scribe-footer-general">
-          <div className="scribe-footer-category">
-            <a href={@props.privacyPolicy}>Privacy Policy</a>
-          </div>
-
-          <div className="scribe-footer-category">
-            <a href="https://github.com/zooniverse/ScribeAPI">Source & Bugs</a>
-          </div>
+          {
+            if @props.menus? && @props.menus.footer?
+              for item, i in @props.menus.footer
+                <div className="scribe-footer-category custom-footer-link">
+                  <a href={item.url}>{item.label}</a>
+                </div>
+            else
+              <div className="scribe-footer-category half">
+                <a href={@props.privacyPolicy}>Privacy Policy</a>
+              </div>
+              <div className="scribe-footer-category half">
+                <a href="https://github.com/zooniverse/ScribeAPI">Source & Bugs</a>
+              </div>
+          }
         </div>
 
 

--- a/app/assets/javascripts/partials/footer.cjsx
+++ b/app/assets/javascripts/partials/footer.cjsx
@@ -38,9 +38,14 @@ Footer = React.createClass
           {
             if @props.menus? && @props.menus.footer?
               for item, i in @props.menus.footer
-                <div className="scribe-footer-category custom-footer-link">
-                  <a href={item.url}>{item.label}</a>
-                </div>
+                if item.url?
+                  <div className="scribe-footer-category custom-footer-link">
+                    <a href={item.url}>{item.label}</a>
+                  </div>
+                else
+                  <div className="scribe-footer-category custom-footer-link">
+                    {item.label}
+                  </div>
             else
               <div>
                 <div className="scribe-footer-category">

--- a/app/assets/javascripts/partials/footer.cjsx
+++ b/app/assets/javascripts/partials/footer.cjsx
@@ -16,7 +16,7 @@ Footer = React.createClass
       </a>
 
       <div className="scribe-footer-content">
-        <div className="scribe-footer-heading">This project is built using Scribe: Document transcription, crowdsourced</div>
+        <div className="scribe-footer-heading">This project is built using Scribe: document transcription, crowdsourced.</div>
 
         {if @state.categories?
           <div className="scribe-footer-projects">

--- a/app/assets/javascripts/partials/main-header.cjsx
+++ b/app/assets/javascripts/partials/main-header.cjsx
@@ -33,10 +33,20 @@ module.exports = React.createClass
             title = workflow.name.charAt(0).toUpperCase() + workflow.name.slice(1)
             <Link key={key} to="/#{workflow.name}" activeClassName="selected" className="main-header-item">{title}</Link>
         }
-        { # Page tabs:
-          @props.pages?.map (page, key) =>
-            formatted_name = page.name.replace("_", " ")
-            <Link key={key} to="/#{page.name.toLowerCase()}" activeClassName="selected" className="main-header-item">{formatted_name}</Link>
+        { # Page tabs, check for main menu
+          if @props.menus? && @props.menus.main?
+            for item, i in @props.menus.main
+              if item.page?
+                <Link key={item.page} to="/#{item.page}" activeClassName="selected" className="main-header-item">{item.label}</Link>
+              else if item.url?
+                <a href="#{item.url}" className="main-header-item">{item.label}</a>
+              else
+                <a className="main-header-item">{item.label}</a>
+          # Otherwise, just list all the pages in default order
+          else
+            @props.pages?.map (page, key) =>
+              formatted_name = page.name.replace("_", " ")
+              <Link key={key} to="/#{page.name.toLowerCase()}" activeClassName="selected" className="main-header-item">{formatted_name}</Link>
         }
 
         { # include feedback tab if defined

--- a/app/assets/stylesheets/common.styl
+++ b/app/assets/stylesheets/common.styl
@@ -235,8 +235,12 @@ div.home-page
 
   .scribe-footer-category
     display: inline-block
-    width: 49%;
-    text-align: center;
+    width: 49%
+    text-align: center
+
+    &.custom-footer-link
+      width: auto
+      padding: 6px 20px
 
   .scribe-footer-content
     float: none

--- a/app/assets/stylesheets/common.styl
+++ b/app/assets/stylesheets/common.styl
@@ -231,6 +231,7 @@ div.home-page
   .scribe-footer-general
     border-top: solid #808080 1px;
     padding-top: 10px
+    padding-bottom: 10px
     text-align: center
 
   .scribe-footer-category

--- a/app/assets/stylesheets/common.styl
+++ b/app/assets/stylesheets/common.styl
@@ -231,7 +231,7 @@ div.home-page
   .scribe-footer-general
     border-top: solid #808080 1px;
     padding-top: 10px
-    padding-bottom: 10px
+    padding-bottom: 40px
     text-align: center
 
   .scribe-footer-category

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -16,6 +16,7 @@ class Project
   field  :scientists,        type: Array,  default: []
   field  :developers,        type: Array,  default: []
   field  :pages,             type: Array,  default: []
+  field  :menus,             type: Hash,   default: {}
   field  :logo,              type: String
   field  :background,        type: String
   field  :favicon,           type: String

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -17,6 +17,7 @@ class Project
   field  :developers,        type: Array,  default: []
   field  :pages,             type: Array,  default: []
   field  :menus,             type: Hash,   default: {}
+  field  :partials,          type: Hash,   default: {}
   field  :logo,              type: String
   field  :background,        type: String
   field  :favicon,           type: String

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -1,5 +1,5 @@
 class ProjectSerializer < ActiveModel::MongoidSerializer
-  attributes :id, :title, :short_title, :summary, :home_page_content, :organizations , :team, :pages, :logo, :background, :workflows, :forum, :tutorial, :feedback_form_url, :metadata_search, :terms_map, :blog_url, :discuss_url, :privacy_policy
+  attributes :id, :title, :short_title, :summary, :home_page_content, :organizations , :team, :pages, :menus, :logo, :background, :workflows, :forum, :tutorial, :feedback_form_url, :metadata_search, :terms_map, :blog_url, :discuss_url, :privacy_policy
   has_many :workflows
 
   # delegate :current_or_guest_user, to: :scope

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -1,5 +1,5 @@
 class ProjectSerializer < ActiveModel::MongoidSerializer
-  attributes :id, :title, :short_title, :summary, :home_page_content, :organizations , :team, :pages, :menus, :logo, :background, :workflows, :forum, :tutorial, :feedback_form_url, :metadata_search, :terms_map, :blog_url, :discuss_url, :privacy_policy
+  attributes :id, :title, :short_title, :summary, :home_page_content, :organizations , :team, :pages, :menus, :partials, :logo, :background, :workflows, :forum, :tutorial, :feedback_form_url, :metadata_search, :terms_map, :blog_url, :discuss_url, :privacy_policy
   has_many :workflows
 
   # delegate :current_or_guest_user, to: :scope

--- a/lib/tasks/project.rake
+++ b/lib/tasks/project.rake
@@ -137,7 +137,8 @@ namespace :project do
       organizations: [],
       analytics: nil,
       forum: nil,
-      menus: {}
+      menus: {},
+      partials: {}
     }
     # Set all valid fields from hash:
     project_hash = project_hash.inject(project_defaults) { |h, (k,v)| h[k] = v if Project.fields.keys.include?(k.to_s); h }
@@ -189,6 +190,23 @@ namespace :project do
           updated_at: updated_at,
           group_browser: group_browser
         }
+      end
+    end
+
+    # load partial content if exists
+    project.partials = {}
+    partials_path = Rails.root.join('project', project_key, 'content', 'partials')
+    if File.directory? partials_path
+      Dir.foreach(partials_path).each do |file|
+        path = Rails.root.join partials_path, file
+        next if File.directory? path
+        next if ! ['.html','.erb','.md'].include? path.extname
+
+        key = file.split('.').first
+        content = File.read path
+        puts "  Loading partial: \"#{key}\" (#{content.size}b)"
+
+        project.partials[key] = content
       end
     end
 

--- a/lib/tasks/project.rake
+++ b/lib/tasks/project.rake
@@ -136,7 +136,8 @@ namespace :project do
       team: [],
       organizations: [],
       analytics: nil,
-      forum: nil
+      forum: nil,
+      menus: {}
     }
     # Set all valid fields from hash:
     project_hash = project_hash.inject(project_defaults) { |h, (k,v)| h[k] = v if Project.fields.keys.include?(k.to_s); h }

--- a/project/emigrant/assets/css/styles.css
+++ b/project/emigrant/assets/css/styles.css
@@ -438,3 +438,7 @@ div.home-page {
     margin: 1em;
   }
 }
+
+.scribe-footer .scribe-footer-general {
+  padding-bottom: 10px;
+}

--- a/project/emigrant/content/partials/footer.html.erb
+++ b/project/emigrant/content/partials/footer.html.erb
@@ -5,5 +5,6 @@
       and <a href="http://www.nypl.org/locations/divisions/milstein">The Irma and Paul Milstein Division of United States History, Local History and Genealogy</a>
       with generous support from:</p>
     <p><a href="http://www.neh.gov/"><img src="/assets/neh_logo.png" alt="National Endowment for the Humanities" title="National Endowment for the Humanities" /></a></p>
+    <p>&copy; The New York Public Library, Astor, Lennox, and Tilden Foundation 2013-2015</p>
   </div>
 </div>

--- a/project/emigrant/content/partials/footer.html.erb
+++ b/project/emigrant/content/partials/footer.html.erb
@@ -1,0 +1,9 @@
+<div class="scribe-footer-credits">
+  <div>
+    <p>A collaboration between
+      <a href="http://www.nypl.org/collections/labs">New York Public Library Labs</a>
+      and <a href="http://www.nypl.org/locations/divisions/milstein">Irma and Paul Milstein Division of United States History, Local History and Genealogy</a>
+      with generous support from:</p>
+    <p><a href="http://www.neh.gov/"><img src="/assets/neh_logo.png" alt="National Endowment for the Humanities" title="National Endowment for the Humanities" /></a></p>
+  </div>
+</div>

--- a/project/emigrant/content/partials/footer.html.erb
+++ b/project/emigrant/content/partials/footer.html.erb
@@ -1,8 +1,8 @@
 <div class="scribe-footer-credits">
   <div>
-    <p>A collaboration between
+    <p>Emigrant City is a collaboration between
       <a href="http://www.nypl.org/collections/labs">New York Public Library Labs</a>
-      and <a href="http://www.nypl.org/locations/divisions/milstein">Irma and Paul Milstein Division of United States History, Local History and Genealogy</a>
+      and <a href="http://www.nypl.org/locations/divisions/milstein">The Irma and Paul Milstein Division of United States History, Local History and Genealogy</a>
       with generous support from:</p>
     <p><a href="http://www.neh.gov/"><img src="/assets/neh_logo.png" alt="National Endowment for the Humanities" title="National Endowment for the Humanities" /></a></p>
   </div>

--- a/project/emigrant/project.json
+++ b/project/emigrant/project.json
@@ -46,5 +46,21 @@
   "forum": {
     "type": "discourse",
     "base_url": "http://scribe-forum.nypl-labs.biz"
+  },
+
+  "menus": {
+    "main": [
+      {"label": "Intro", "page": "intro"},
+      {"label": "Data", "page": "data"},
+      {"label": "About", "page": "about"}
+    ],
+    "footer": [
+      {"label": "Privacy Policy", "url": "http://www.nypl.org/help/about-nypl/legal-notices/privacy-policy"},
+      {"label": "Rules and Regulations", "url": "http://www.nypl.org/help/about-nypl/legal-notices/rules-and-regulations"},
+      {"label": "Policy on Patron-Generated Web Content", "url": "http://www.nypl.org/policy-patron-generated-web-content"},
+      {"label": "Terms and Conditions", "url": "http://www.nypl.org/help/about-nypl/legal-notices/website-terms-and-conditions"},
+      {"label": "Source & Bugs", "url": "https://github.com/zooniverse/ScribeAPI"},
+      {"label": "© The New York Public Library, Astor, Lennox, and Tilden Foundation 2013-2015"}
+    ]
   }
 }

--- a/project/emigrant/project.json
+++ b/project/emigrant/project.json
@@ -59,8 +59,7 @@
       {"label": "Rules and Regulations", "url": "http://www.nypl.org/help/about-nypl/legal-notices/rules-and-regulations"},
       {"label": "Policy on Patron-Generated Web Content", "url": "http://www.nypl.org/policy-patron-generated-web-content"},
       {"label": "Terms and Conditions", "url": "http://www.nypl.org/help/about-nypl/legal-notices/website-terms-and-conditions"},
-      {"label": "Source & Bugs", "url": "https://github.com/zooniverse/ScribeAPI"},
-      {"label": "© The New York Public Library, Astor, Lennox, and Tilden Foundation 2013-2015"}
+      {"label": "Source & Bugs", "url": "https://github.com/zooniverse/ScribeAPI"}
     ]
   }
 }


### PR DESCRIPTION
- Add ability to select/order project pages in main menu (#487) and footer menu
- Add ability to customize footer content per project
- Customize Emigrants main menu, footer menu, footer content (#512)

In order to to this:

- Added optional `menus` key in project config which is a hash of menus that appear in the app (currently "main" and "footer"); menus contain a list of menu items (label, url or page)
- Added optional folder `partials` in project's `content` directory which loads partial html content (currently supports "footer.html.erb").  Can be referred to in project via `project.partials["footer"]`

Everything will act like before if none of these additions are implemented per project