### PR TITLE
Fixing bug where retire_limit is never met in Mark

### DIFF
--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -150,7 +150,6 @@ class Subject
 
   def retire!
     return if status == "bad"
-    return if classifying_user_ids.length < workflow.retire_limit
     status! 'retired'
     subject_set.subject_completed_on_workflow(workflow) if ! workflow.nil?
     

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -6,7 +6,7 @@ class Workflow
   field    :key, 				                                     type: String
   field    :label,                                           type: String
   field    :first_task,                                      type: String
-  field    :retire_limit,                                    type: Integer,   default: 3
+  field    :retire_limit,                                    type: Float,     default: 0.75
   field    :subject_fetch_limit,                             type: Integer,   default: 10
   field    :generates_subjects,                              type: Boolean,   default: true
   field    :generates_subjects_after,                        type: Integer,   default: 0

--- a/project/emigrant/project.json
+++ b/project/emigrant/project.json
@@ -44,6 +44,8 @@
     "google_analytics_client_id": "UA-69673163-1"
   },
 
+  "discuss_url": "http://forum.emigrantcity.nypl.org",
+
   "forum": {
     "type": "discourse",
     "base_url": "http://forum.emigrantcity.nypl.org"

--- a/project/emigrant/workflows/mark.json
+++ b/project/emigrant/workflows/mark.json
@@ -4,6 +4,7 @@
   "subject_fetch_limit":"10",
   "generates_subjects": true,
   "generates_subjects_for": "transcribe",
+  "retire_limit": 0.75,
 
   "first_task":"mark_primary",
 


### PR DESCRIPTION
Originally workflow.retire_limit was an int (e.g. 3). Later, after implementing the completion_assessment_task we realized this should be a percentage (e.g. 0.75) to establish the target majority threshold when multiple conflicting completion_assessment votes have been cast. (In the future, we might modify this to take the time into account - so that a lot of early "yes" votes do not dominate later equally legitimate "no" votes.) In any case, we've configured our workflows with retire_limit 3, but we're checking that against the percentage of "no" votes when determining whether or not to retire. But [number of "no" votes] / [number of votes] will never be greater than 1 much less 3, so nothing is retired.

Also adding Emigrant discuss url.