### PR TITLE
Disable strict SSL checking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ WORKDIR /src/
 
 RUN bundle install
 
+RUN npm conf set strict-ssl false
+
 RUN npm install
 
 EXPOSE 80


### PR DESCRIPTION
Old versions of npm apparently can't verify certs

npm/npm#4379